### PR TITLE
Move HTP backend docs to docs/ as unified build and test guide

### DIFF
--- a/docs/how-to-build-and-test-htp-backend.md
+++ b/docs/how-to-build-and-test-htp-backend.md
@@ -15,6 +15,7 @@ The build produces two shared libraries:
 
 ## Prerequisites
 
+- nntrainer basic setup must be completed first. See [Getting Started](getting-started.md).
 - **Hexagon SDK >= v6.0.0.2** with setup complete
 - **CMake >= 3.14.3**
 - `HEXAGON_SDK_HOME` environment variable pointing to SDK root

--- a/docs/how-to-build-and-test-htp-backend.md
+++ b/docs/how-to-build-and-test-htp-backend.md
@@ -48,9 +48,23 @@ build/nntrainer/tensor/htp_backend/htp_lib/
 export HEXAGON_SDK_HOME=/path/to/hexagon/sdk
 
 cd nntrainer/nntrainer/tensor/htp_backend
-build_cmake android
-build_cmake hexagon DSP_ARCH=v73/v75
+./build_htp.sh
 ```
+
+After a successful build, the output files are located at:
+
+```
+nntrainer/nntrainer/tensor/htp_backend/build_htp/
+├── libhtp_ops.so        # Host stub library
+├── libhtp_ops_skel.so   # DSP skel library
+└── htp_ops_test         # Test binary
+```
+
+### DSP architecture setting
+
+The target device's DSP architecture must be specified via the `DSP_ARCH`
+option inside `build_htp.sh`. Set it to `v73` or `v75` depending on the
+Android device before running the build.
 
 ## Running Unit Tests
 

--- a/docs/how-to-build-and-test-htp-backend.md
+++ b/docs/how-to-build-and-test-htp-backend.md
@@ -32,9 +32,7 @@ meson setup build -Dwerror=false -Denable-htp=true
 ninja -C build
 ```
 
-### Build output
-
-After a successful build:
+Build output:
 
 ```
 build/nntrainer/tensor/htp_backend/htp_lib/
@@ -52,7 +50,7 @@ cd nntrainer/nntrainer/tensor/htp_backend
 ./build_htp.sh
 ```
 
-After a successful build, the output files are located at:
+Build output:
 
 ```
 nntrainer/nntrainer/tensor/htp_backend/build_htp/


### PR DESCRIPTION
## Summary

- Consolidate `htp_backend/BUILD.md` and `htp_backend/README.md` into `docs/how-to-build-and-test-htp-backend.md`
- Simplify document to focus on build/test execution commands only
- Update standalone build to use `build_htp.sh` with output in `build_htp/`
- Add DSP_ARCH (v73/v75) configuration note
- Update unittest section with `android_test.sh` workflow
- Add getting-started prerequisite reference

## Test plan

- [ ] Verify `docs/how-to-build-and-test-htp-backend.md` renders correctly
- [ ] Confirm removed files (`htp_backend/BUILD.md`, `htp_backend/README.md`) have no remaining references

https://claude.ai/code/session_01CVDe36wd6wtsPvWCT6AbYV