### PR TITLE
Add HTP backend build and test documentation including run.sh usage

### DIFF
--- a/docs/how-to-build-and-test-htp-backend.md
+++ b/docs/how-to-build-and-test-htp-backend.md
@@ -96,7 +96,11 @@ The script performs the following steps:
 **Requirements:**
 - A Qualcomm Android device must be connected and accessible via `adb`.
 - The standalone cmake build must be completed first (`./build_htp.sh`).
-- `adb` must be available at `/usr/lib/android-sdk/platform-tools/adb` (the default path in `run.sh`).
+- The `adb_dir` variable at the top of `run.sh` must be set to the actual `adb` path on your system before running the script:
+  ```bash
+  # run.sh
+  adb_dir="/usr/lib/android-sdk/platform-tools/adb"  # modify this to match your adb path
+  ```
 
 ## Running Unit Tests
 

--- a/docs/how-to-build-and-test-htp-backend.md
+++ b/docs/how-to-build-and-test-htp-backend.md
@@ -85,14 +85,6 @@ cd nntrainer/nntrainer/tensor/htp_backend
 ./run.sh /data/local/tmp/my_test_dir
 ```
 
-The script performs the following steps:
-
-1. Pushes the built artifacts to the device via `adb push`:
-   - `build_htp/libhtp_ops.so`
-   - `build_htp/libhtp_ops_skel.so`
-   - `build_htp/htp_ops_test`
-2. Executes `htp_ops_test` on the device with `LD_LIBRARY_PATH` set to the target directory.
-
 **Requirements:**
 - A Qualcomm Android device must be connected and accessible via `adb`.
 - The standalone cmake build must be completed first (`./build_htp.sh`).

--- a/docs/how-to-build-and-test-htp-backend.md
+++ b/docs/how-to-build-and-test-htp-backend.md
@@ -69,6 +69,35 @@ Android device before running the build.
 build_cmake hexagon DSP_ARCH=<dsp_ver> 
 ```
 
+## Running Standalone Tests on Device
+
+After the [Standalone cmake build](#standalone-cmake-build-without-meson),
+`run.sh` automates pushing the build artifacts to a connected Android device
+and executing the test binary (`htp_ops_test`) compiled from `host/test.c`.
+
+```bash
+cd nntrainer/nntrainer/tensor/htp_backend
+
+# Use default target directory (/data/local/tmp/htp_backend)
+./run.sh
+
+# Or specify a custom target directory on the device
+./run.sh /data/local/tmp/my_test_dir
+```
+
+The script performs the following steps:
+
+1. Pushes the built artifacts to the device via `adb push`:
+   - `build_htp/libhtp_ops.so`
+   - `build_htp/libhtp_ops_skel.so`
+   - `build_htp/htp_ops_test`
+2. Executes `htp_ops_test` on the device with `LD_LIBRARY_PATH` set to the target directory.
+
+**Requirements:**
+- A Qualcomm Android device must be connected and accessible via `adb`.
+- The standalone cmake build must be completed first (`./build_htp.sh`).
+- `adb` must be available at `/usr/lib/android-sdk/platform-tools/adb` (the default path in `run.sh`).
+
 ## Running Unit Tests
 
 Unit tests for the HTP backend are located under `test/unittest/`.


### PR DESCRIPTION
## Summary

- `docs/how-to-build-and-test-htp-backend.md` 파일 추가
- Standalone cmake build 이후 연결된 안드로이드 단말에서 `test.c` 기반 테스트를 직접 실행하는 `run.sh` 사용법 문서화
- `run.sh` 내부의 `adb_dir` 변수를 사용자 환경에 맞게 수정해야 함을 안내

## Test plan

- [ ] 문서 내용이 `htp_libs_integration` 브랜치의 기존 빌드 문서와 충돌 없이 통합되는지 확인
- [ ] `run.sh` 사용법 및 `adb_dir` 수정 안내가 정확한지 확인