### PR TITLE
Connect dotFloat to HTP with FP32-to-FP16 weight quantization

### DIFF
--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -881,10 +881,16 @@ Tensor &FloatTensor::dotFloat(Tensor const &input, Tensor &output, bool trans,
         if (err == 0) {
           memcpy(act_buf, data, act_size);
 
-          // Quantize FP32 weights to FP16
+          // Transpose [K × N] → [N × K] and quantize FP32 → FP16.
+          // HTP kernel expects weight in [N × K] layout:
+          //   C[i,j] = Σ_l A[i,l] * W[j,l]  (W stored as weight[j * K + l])
+          // but mdata is row-major [K × N] (stride N), so we transpose.
           _FP16 *wt_fp16 = static_cast<_FP16 *>(wt_buf);
-          for (size_t i = 0; i < static_cast<size_t>(K) * N; ++i) {
-            wt_fp16[i] = static_cast<_FP16>(mdata[i]);
+          for (unsigned int n_idx = 0; n_idx < N; ++n_idx) {
+            for (unsigned int k_idx = 0; k_idx < K; ++k_idx) {
+              wt_fp16[n_idx * K + k_idx] =
+                static_cast<_FP16>(mdata[k_idx * N + n_idx]);
+            }
           }
 
           err = htp.htp_ops_mat_mul_af32_wf16_of32(handle, out_fd, 0, act_fd,

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -28,6 +28,7 @@
 
 #if defined(ENABLE_HTP) && ENABLE_HTP == 1
 #include "htp_interface.h"
+#include <unordered_map>
 #endif
 
 namespace nntrainer {
@@ -858,7 +859,8 @@ Tensor &FloatTensor::dotFloat(Tensor const &input, Tensor &output, bool trans,
 
 #if defined(ENABLE_FP16) && defined(ENABLE_HTP) && ENABLE_HTP == 1
   // HTP accelerated path: only for standard (non-transposed) matmul without
-  // accumulation. Quantizes FP32 weights to FP16 on the fly.
+  // accumulation. Converts FP32 weights to FP16 once and caches in shared
+  // memory so subsequent calls skip the transpose+convert overhead.
   // Falls through to CPU for unsupported configurations.
   if (!trans && !trans_in && beta == 0.0f) {
     auto &htp = nntrainer::htp::HtpInterface::instance();
@@ -866,48 +868,69 @@ Tensor &FloatTensor::dotFloat(Tensor const &input, Tensor &output, bool trans,
         htp.free_shared_mem_buf && htp.get_global_handle) {
       auto handle = htp.get_global_handle();
       if (handle != 0) {
-        size_t act_size = M * K * sizeof(float);
-        size_t wt_size = K * N * sizeof(_FP16);
-        size_t out_size = M * N * sizeof(float);
-        size_t total_size = act_size + wt_size + out_size;
+        // --- Weight cache: convert FP32→FP16 [N×K] once, reuse thereafter ---
+        struct WtCacheEntry {
+          void *buf;
+          int fd;
+          size_t size;
+        };
+        static std::unordered_map<const float *, WtCacheEntry> wt_cache;
 
-        size_t act_offset = 0;
-        size_t wt_offset = act_size;
-        size_t out_offset = act_size + wt_size;
+        size_t wt_size = static_cast<size_t>(K) * N * sizeof(_FP16);
+        int wt_fd = -1;
+        void *wt_buf = nullptr;
+        bool wt_cached = false;
 
-        void *io_buf = nullptr;
-        int io_fd = -1;
-
-        int err = htp.alloc_shared_mem_buf(&io_buf, &io_fd, total_size);
-
-        if (err == 0) {
-          char *base = static_cast<char *>(io_buf);
-          memcpy(base + act_offset, data, act_size);
-
-          // Transpose [K × N] → [N × K] and quantize FP32 → FP16.
-          // HTP kernel expects weight in [N × K] layout:
-          //   C[i,j] = Σ_l A[i,l] * W[j,l]  (W stored as weight[j * K + l])
-          // but mdata is row-major [K × N] (stride N), so we transpose.
-          _FP16 *wt_fp16 = reinterpret_cast<_FP16 *>(base + wt_offset);
-          for (unsigned int n_idx = 0; n_idx < N; ++n_idx) {
-            for (unsigned int k_idx = 0; k_idx < K; ++k_idx) {
-              wt_fp16[n_idx * K + k_idx] =
-                static_cast<_FP16>(mdata[k_idx * N + n_idx]);
-            }
-          }
-
-          err = htp.htp_ops_mat_mul_af32_wf16_of32(
-            handle, io_fd, out_offset, io_fd, act_offset, io_fd, wt_offset, M,
-            K, N);
+        auto wt_it = wt_cache.find(mdata);
+        if (wt_it != wt_cache.end() && wt_it->second.size == wt_size) {
+          wt_buf = wt_it->second.buf;
+          wt_fd = wt_it->second.fd;
+          wt_cached = true;
+        } else {
+          // First call for this weight: allocate, transpose+convert, cache
+          int err = htp.alloc_shared_mem_buf(&wt_buf, &wt_fd, wt_size);
           if (err == 0) {
-            memcpy(rdata, base + out_offset, out_size);
-            htp.free_shared_mem_buf(io_buf, io_fd, total_size);
-            return output;
+            _FP16 *wt_fp16 = static_cast<_FP16 *>(wt_buf);
+            for (unsigned int n_idx = 0; n_idx < N; ++n_idx) {
+              for (unsigned int k_idx = 0; k_idx < K; ++k_idx) {
+                wt_fp16[n_idx * K + k_idx] =
+                  static_cast<_FP16>(mdata[k_idx * N + n_idx]);
+              }
+            }
+            wt_cache[mdata] = {wt_buf, wt_fd, wt_size};
+            wt_cached = true;
           }
         }
 
-        if (io_buf)
-          htp.free_shared_mem_buf(io_buf, io_fd, total_size);
+        if (wt_cached) {
+          // --- Activation + output: allocate per-call ---
+          size_t act_size = static_cast<size_t>(M) * K * sizeof(float);
+          size_t out_size = static_cast<size_t>(M) * N * sizeof(float);
+          size_t io_size = act_size + out_size;
+
+          void *io_buf = nullptr;
+          int io_fd = -1;
+          int err = htp.alloc_shared_mem_buf(&io_buf, &io_fd, io_size);
+
+          if (err == 0) {
+            char *base = static_cast<char *>(io_buf);
+            size_t act_offset = 0;
+            size_t out_offset = act_size;
+
+            memcpy(base + act_offset, data, act_size);
+
+            err = htp.htp_ops_mat_mul_af32_wf16_of32(
+              handle, io_fd, out_offset, io_fd, act_offset, wt_fd, 0, M, K, N);
+            if (err == 0) {
+              memcpy(rdata, base + out_offset, out_size);
+              htp.free_shared_mem_buf(io_buf, io_fd, io_size);
+              return output;
+            }
+          }
+
+          if (io_buf)
+            htp.free_shared_mem_buf(io_buf, io_fd, io_size);
+        }
         // Fall through to CPU path on error
       }
     }

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -869,23 +869,26 @@ Tensor &FloatTensor::dotFloat(Tensor const &input, Tensor &output, bool trans,
         size_t act_size = M * K * sizeof(float);
         size_t wt_size = K * N * sizeof(_FP16);
         size_t out_size = M * N * sizeof(float);
+        size_t total_size = act_size + wt_size + out_size;
 
-        void *act_buf = nullptr, *wt_buf = nullptr, *out_buf = nullptr;
-        int act_fd = -1, wt_fd = -1, out_fd = -1;
+        size_t act_offset = 0;
+        size_t wt_offset = act_size;
+        size_t out_offset = act_size + wt_size;
 
-        int err = 0;
-        err |= htp.alloc_shared_mem_buf(&act_buf, &act_fd, act_size);
-        err |= htp.alloc_shared_mem_buf(&wt_buf, &wt_fd, wt_size);
-        err |= htp.alloc_shared_mem_buf(&out_buf, &out_fd, out_size);
+        void *io_buf = nullptr;
+        int io_fd = -1;
+
+        int err = htp.alloc_shared_mem_buf(&io_buf, &io_fd, total_size);
 
         if (err == 0) {
-          memcpy(act_buf, data, act_size);
+          char *base = static_cast<char *>(io_buf);
+          memcpy(base + act_offset, data, act_size);
 
           // Transpose [K × N] → [N × K] and quantize FP32 → FP16.
           // HTP kernel expects weight in [N × K] layout:
           //   C[i,j] = Σ_l A[i,l] * W[j,l]  (W stored as weight[j * K + l])
           // but mdata is row-major [K × N] (stride N), so we transpose.
-          _FP16 *wt_fp16 = static_cast<_FP16 *>(wt_buf);
+          _FP16 *wt_fp16 = reinterpret_cast<_FP16 *>(base + wt_offset);
           for (unsigned int n_idx = 0; n_idx < N; ++n_idx) {
             for (unsigned int k_idx = 0; k_idx < K; ++k_idx) {
               wt_fp16[n_idx * K + k_idx] =
@@ -893,23 +896,18 @@ Tensor &FloatTensor::dotFloat(Tensor const &input, Tensor &output, bool trans,
             }
           }
 
-          err = htp.htp_ops_mat_mul_af32_wf16_of32(handle, out_fd, 0, act_fd,
-                                                   0, wt_fd, 0, M, K, N);
+          err = htp.htp_ops_mat_mul_af32_wf16_of32(
+            handle, io_fd, out_offset, io_fd, act_offset, io_fd, wt_offset, M,
+            K, N);
           if (err == 0) {
-            memcpy(rdata, out_buf, out_size);
-            htp.free_shared_mem_buf(act_buf, act_fd, act_size);
-            htp.free_shared_mem_buf(wt_buf, wt_fd, wt_size);
-            htp.free_shared_mem_buf(out_buf, out_fd, out_size);
+            memcpy(rdata, base + out_offset, out_size);
+            htp.free_shared_mem_buf(io_buf, io_fd, total_size);
             return output;
           }
         }
 
-        if (act_buf)
-          htp.free_shared_mem_buf(act_buf, act_fd, act_size);
-        if (wt_buf)
-          htp.free_shared_mem_buf(wt_buf, wt_fd, wt_size);
-        if (out_buf)
-          htp.free_shared_mem_buf(out_buf, out_fd, out_size);
+        if (io_buf)
+          htp.free_shared_mem_buf(io_buf, io_fd, total_size);
         // Fall through to CPU path on error
       }
     }

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -28,7 +28,6 @@
 
 #if defined(ENABLE_HTP) && ENABLE_HTP == 1
 #include "htp_interface.h"
-#include <unordered_map>
 #endif
 
 namespace nntrainer {
@@ -859,8 +858,7 @@ Tensor &FloatTensor::dotFloat(Tensor const &input, Tensor &output, bool trans,
 
 #if defined(ENABLE_FP16) && defined(ENABLE_HTP) && ENABLE_HTP == 1
   // HTP accelerated path: only for standard (non-transposed) matmul without
-  // accumulation. Converts FP32 weights to FP16 once and caches in shared
-  // memory so subsequent calls skip the transpose+convert overhead.
+  // accumulation. Converts FP32 weights to FP16 on the fly.
   // Falls through to CPU for unsupported configurations.
   if (!trans && !trans_in && beta == 0.0f) {
     auto &htp = nntrainer::htp::HtpInterface::instance();
@@ -868,69 +866,48 @@ Tensor &FloatTensor::dotFloat(Tensor const &input, Tensor &output, bool trans,
         htp.free_shared_mem_buf && htp.get_global_handle) {
       auto handle = htp.get_global_handle();
       if (handle != 0) {
-        // --- Weight cache: convert FP32→FP16 [N×K] once, reuse thereafter ---
-        struct WtCacheEntry {
-          void *buf;
-          int fd;
-          size_t size;
-        };
-        static std::unordered_map<const float *, WtCacheEntry> wt_cache;
-
+        size_t act_size = static_cast<size_t>(M) * K * sizeof(float);
         size_t wt_size = static_cast<size_t>(K) * N * sizeof(_FP16);
-        int wt_fd = -1;
-        void *wt_buf = nullptr;
-        bool wt_cached = false;
+        size_t out_size = static_cast<size_t>(M) * N * sizeof(float);
+        size_t total_size = act_size + wt_size + out_size;
 
-        auto wt_it = wt_cache.find(mdata);
-        if (wt_it != wt_cache.end() && wt_it->second.size == wt_size) {
-          wt_buf = wt_it->second.buf;
-          wt_fd = wt_it->second.fd;
-          wt_cached = true;
-        } else {
-          // First call for this weight: allocate, transpose+convert, cache
-          int err = htp.alloc_shared_mem_buf(&wt_buf, &wt_fd, wt_size);
-          if (err == 0) {
-            _FP16 *wt_fp16 = static_cast<_FP16 *>(wt_buf);
-            for (unsigned int n_idx = 0; n_idx < N; ++n_idx) {
-              for (unsigned int k_idx = 0; k_idx < K; ++k_idx) {
-                wt_fp16[n_idx * K + k_idx] =
-                  static_cast<_FP16>(mdata[k_idx * N + n_idx]);
-              }
-            }
-            wt_cache[mdata] = {wt_buf, wt_fd, wt_size};
-            wt_cached = true;
-          }
-        }
+        size_t act_offset = 0;
+        size_t wt_offset = act_size;
+        size_t out_offset = act_size + wt_size;
 
-        if (wt_cached) {
-          // --- Activation + output: allocate per-call ---
-          size_t act_size = static_cast<size_t>(M) * K * sizeof(float);
-          size_t out_size = static_cast<size_t>(M) * N * sizeof(float);
-          size_t io_size = act_size + out_size;
+        void *io_buf = nullptr;
+        int io_fd = -1;
 
-          void *io_buf = nullptr;
-          int io_fd = -1;
-          int err = htp.alloc_shared_mem_buf(&io_buf, &io_fd, io_size);
+        int err = htp.alloc_shared_mem_buf(&io_buf, &io_fd, total_size);
 
-          if (err == 0) {
-            char *base = static_cast<char *>(io_buf);
-            size_t act_offset = 0;
-            size_t out_offset = act_size;
+        if (err == 0) {
+          char *base = static_cast<char *>(io_buf);
+          memcpy(base + act_offset, data, act_size);
 
-            memcpy(base + act_offset, data, act_size);
-
-            err = htp.htp_ops_mat_mul_af32_wf16_of32(
-              handle, io_fd, out_offset, io_fd, act_offset, wt_fd, 0, M, K, N);
-            if (err == 0) {
-              memcpy(rdata, base + out_offset, out_size);
-              htp.free_shared_mem_buf(io_buf, io_fd, io_size);
-              return output;
+          // Transpose [K × N] → [N × K] and quantize FP32 → FP16.
+          // HTP kernel expects weight in [N × K] layout:
+          //   C[i,j] = Σ_l A[i,l] * W[j,l]  (W stored as weight[j * K + l])
+          // but mdata is row-major [K × N] (stride N), so we transpose.
+          _FP16 *wt_fp16 = reinterpret_cast<_FP16 *>(base + wt_offset);
+          for (unsigned int n_idx = 0; n_idx < N; ++n_idx) {
+            for (unsigned int k_idx = 0; k_idx < K; ++k_idx) {
+              wt_fp16[n_idx * K + k_idx] =
+                static_cast<_FP16>(mdata[k_idx * N + n_idx]);
             }
           }
 
-          if (io_buf)
-            htp.free_shared_mem_buf(io_buf, io_fd, io_size);
+          err = htp.htp_ops_mat_mul_af32_wf16_of32(
+            handle, io_fd, out_offset, io_fd, act_offset, io_fd, wt_offset, M,
+            K, N);
+          if (err == 0) {
+            memcpy(rdata, base + out_offset, out_size);
+            htp.free_shared_mem_buf(io_buf, io_fd, total_size);
+            return output;
+          }
         }
+
+        if (io_buf)
+          htp.free_shared_mem_buf(io_buf, io_fd, total_size);
         // Fall through to CPU path on error
       }
     }

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -856,6 +856,60 @@ Tensor &FloatTensor::dotFloat(Tensor const &input, Tensor &output, bool trans,
   float *rdata = output.getData<float>();
   const float alpha = 1.0f;
 
+#if defined(ENABLE_FP16) && defined(ENABLE_HTP) && ENABLE_HTP == 1
+  // HTP accelerated path: only for standard (non-transposed) matmul without
+  // accumulation. Quantizes FP32 weights to FP16 on the fly.
+  // Falls through to CPU for unsupported configurations.
+  if (!trans && !trans_in && beta == 0.0f) {
+    auto &htp = nntrainer::htp::HtpInterface::instance();
+    if (htp.htp_ops_mat_mul_af32_wf16_of32 && htp.alloc_shared_mem_buf &&
+        htp.free_shared_mem_buf && htp.get_global_handle) {
+      auto handle = htp.get_global_handle();
+      if (handle != 0) {
+        size_t act_size = M * K * sizeof(float);
+        size_t wt_size = K * N * sizeof(_FP16);
+        size_t out_size = M * N * sizeof(float);
+
+        void *act_buf = nullptr, *wt_buf = nullptr, *out_buf = nullptr;
+        int act_fd = -1, wt_fd = -1, out_fd = -1;
+
+        int err = 0;
+        err |= htp.alloc_shared_mem_buf(&act_buf, &act_fd, act_size);
+        err |= htp.alloc_shared_mem_buf(&wt_buf, &wt_fd, wt_size);
+        err |= htp.alloc_shared_mem_buf(&out_buf, &out_fd, out_size);
+
+        if (err == 0) {
+          memcpy(act_buf, data, act_size);
+
+          // Quantize FP32 weights to FP16
+          _FP16 *wt_fp16 = static_cast<_FP16 *>(wt_buf);
+          for (size_t i = 0; i < static_cast<size_t>(K) * N; ++i) {
+            wt_fp16[i] = static_cast<_FP16>(mdata[i]);
+          }
+
+          err = htp.htp_ops_mat_mul_af32_wf16_of32(handle, out_fd, 0, act_fd,
+                                                   0, wt_fd, 0, M, K, N);
+          if (err == 0) {
+            memcpy(rdata, out_buf, out_size);
+            htp.free_shared_mem_buf(act_buf, act_fd, act_size);
+            htp.free_shared_mem_buf(wt_buf, wt_fd, wt_size);
+            htp.free_shared_mem_buf(out_buf, out_fd, out_size);
+            return output;
+          }
+        }
+
+        if (act_buf)
+          htp.free_shared_mem_buf(act_buf, act_fd, act_size);
+        if (wt_buf)
+          htp.free_shared_mem_buf(wt_buf, wt_fd, wt_size);
+        if (out_buf)
+          htp.free_shared_mem_buf(out_buf, out_fd, out_size);
+        // Fall through to CPU path on error
+      }
+    }
+  }
+#endif // ENABLE_FP16 && ENABLE_HTP
+
   /// shortcut handling in case of vector
   /// for vector, (1 * K) == (K * 1) in current memory layout...
   /// and please note that N, K, M is a fixed place holder after considering


### PR DESCRIPTION
## Summary
- dotFloat (FP32×FP32) 함수에 HTP 가속 경로 추가
- FP32 weight를 FP16으로 on-the-fly 변환 후 htp_ops_mat_mul_af32_wf16_of32 호출
- Weight 레이아웃을 [K×N] → [N×K]로 전치하여 HTP 커널 기대 형식에 맞춤
- 단일 공유 메모리 버퍼(act+wt+out)를 할당하고 offset으로 구분
- HTP 실패 시 기존 CPU BLAS 경로로 안전하게 fallthrough

## Summary
- [ ] ENABLE_HTP=1 + ENABLE_FP16=1 빌드 후 qwen3-0.6b-w32a32 추론 결과 검증
- [ ] HTP 비활성화 환경에서 기존 CPU 경로 정상 동작 확인
