### PR TITLE
Convert !4_0 matmul kernel to x4x2 weight format for HTP

### DIFF
--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -1103,15 +1103,23 @@ Tensor &FloatTensor::dotQnK(Tensor const &input, Tensor &output, bool trans,
           htp.free_shared_mem_buf && htp.get_global_handle) {
         auto handle = htp.get_global_handle();
         if (handle != 0 && K % 256 == 0 && N % 32 == 0) {
+          // Weight data is in block_q4_0x8 interleaved format (from quantizer).
+          // First unpack to standard block_q4_0, then repack to x4x2.
+          size_t nblocks = K / QK4_0;
+          size_t data_size_x8 = (N / 8) * nblocks * sizeof(block_q4_0x8);
+          std::vector<uint8_t> unpacked_q4_0(N * nblocks * sizeof(block_q4_0));
+          Q4_0Utils::unpackBlocksQ4_0x8(
+            reinterpret_cast<const block_q4_0x8 *>(mdata), data_size_x8, N, K,
+            reinterpret_cast<block_q4_0 *>(unpacked_q4_0.data()));
+
           // Repack block_q4_0 weights to x4x2 row-strided format
-          // Compute row stride: K/2 quant bytes + (K/256)*16 scale bytes
           size_t row_stride = (size_t)(K / 2) + (size_t)(K / 256) * 16;
           size_t wt_size = (size_t)N * row_stride;
           std::vector<uint8_t> weight_x4x2(wt_size, 0);
           size_t actual_stride = 0;
           Q4_0Utils::repackToX4x2_Q4_0(
-            reinterpret_cast<const block_q4_0 *>(mdata), weight_x4x2.data(), N,
-            K, &actual_stride);
+            reinterpret_cast<const block_q4_0 *>(unpacked_q4_0.data()),
+            weight_x4x2.data(), N, K, &actual_stride);
 
           size_t act_size = M * K * sizeof(float);
           size_t out_size = M * N * sizeof(float);

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -1103,14 +1103,15 @@ Tensor &FloatTensor::dotQnK(Tensor const &input, Tensor &output, bool trans,
           htp.free_shared_mem_buf && htp.get_global_handle) {
         auto handle = htp.get_global_handle();
         if (handle != 0 && K % 256 == 0 && N % 32 == 0) {
-          // Weight data is in block_q4_0x8 interleaved format (from quantizer).
+          // Weight data is in block_q4_0x4 interleaved format on ARM
+          // (the quantizer's repack_q4_0 packs to x4 on ARM, x8 on x86).
           // Directly convert to x4x2 row-strided format for DSP.
           size_t row_stride = (size_t)(K / 2) + (size_t)(K / 256) * 16;
           size_t wt_size = (size_t)N * row_stride;
           std::vector<uint8_t> weight_x4x2(wt_size, 0);
           size_t actual_stride = 0;
-          Q4_0Utils::repackToX4x2_Q4_0x8(
-            reinterpret_cast<const block_q4_0x8 *>(mdata),
+          Q4_0Utils::repackToX4x2_Q4_0x4(
+            reinterpret_cast<const block_q4_0x4 *>(mdata),
             weight_x4x2.data(), N, K, &actual_stride);
 
           size_t act_size = M * K * sizeof(float);

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -28,6 +28,7 @@
 
 #if defined(ENABLE_HTP) && ENABLE_HTP == 1
 #include "htp_interface.h"
+#include "q4_0_utils.h"
 #endif
 
 namespace nntrainer {
@@ -1097,7 +1098,58 @@ Tensor &FloatTensor::dotQnK(Tensor const &input, Tensor &output, bool trans,
     }
 #elif defined(ENABLE_HTP) && ENABLE_HTP == 1
     {
-      // TODO
+      auto &htp = nntrainer::htp::HtpInterface::instance();
+      if (htp.htp_ops_mat_mul_af32_pwqk0_of32 && htp.alloc_shared_mem_buf &&
+          htp.free_shared_mem_buf && htp.get_global_handle) {
+        auto handle = htp.get_global_handle();
+        if (handle != 0 && K % 256 == 0 && N % 32 == 0) {
+          // Repack block_q4_0 weights to x4x2 row-strided format
+          // Compute row stride: K/2 quant bytes + (K/256)*16 scale bytes
+          size_t row_stride = (size_t)(K / 2) + (size_t)(K / 256) * 16;
+          size_t wt_size = (size_t)N * row_stride;
+          std::vector<uint8_t> weight_x4x2(wt_size, 0);
+          size_t actual_stride = 0;
+          Q4_0Utils::repackToX4x2_Q4_0(
+            reinterpret_cast<const block_q4_0 *>(mdata), weight_x4x2.data(), N,
+            K, &actual_stride);
+
+          size_t act_size = M * K * sizeof(float);
+          size_t out_size = M * N * sizeof(float);
+
+          void *act_buf = nullptr, *wt_buf = nullptr, *out_buf = nullptr;
+          int act_fd = -1, wt_fd = -1, out_fd = -1;
+
+          int err = 0;
+          err |= htp.alloc_shared_mem_buf(&act_buf, &act_fd, act_size);
+          err |= htp.alloc_shared_mem_buf(&wt_buf, &wt_fd, wt_size);
+          err |= htp.alloc_shared_mem_buf(&out_buf, &out_fd, out_size);
+
+          if (err == 0) {
+            memcpy(act_buf, data, act_size);
+            memcpy(wt_buf, weight_x4x2.data(), wt_size);
+
+            // weight_type = 2 (GGML_TYPE_Q4_0)
+            err = htp.htp_ops_mat_mul_af32_pwqk0_of32(
+              handle, out_fd, 0, act_fd, 0, wt_fd, 0, M, K, N, 2);
+            if (err == 0) {
+              memcpy(rdata, out_buf, out_size);
+              htp.free_shared_mem_buf(act_buf, act_fd, act_size);
+              htp.free_shared_mem_buf(wt_buf, wt_fd, wt_size);
+              htp.free_shared_mem_buf(out_buf, out_fd, out_size);
+              break;
+            }
+          }
+
+          if (act_buf)
+            htp.free_shared_mem_buf(act_buf, act_fd, act_size);
+          if (wt_buf)
+            htp.free_shared_mem_buf(wt_buf, wt_fd, wt_size);
+          if (out_buf)
+            htp.free_shared_mem_buf(out_buf, out_fd, out_size);
+        }
+        // Fall through to CPU path on error or unsupported dimensions
+      }
+      gemm_q4_0(M, N, K, data, K, (void *)mdata, N, rdata, N);
     }
 #else
     gemm_q4_0(M, N, K, data, K, (void *)mdata, N, rdata, N);

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -1104,21 +1104,13 @@ Tensor &FloatTensor::dotQnK(Tensor const &input, Tensor &output, bool trans,
         auto handle = htp.get_global_handle();
         if (handle != 0 && K % 256 == 0 && N % 32 == 0) {
           // Weight data is in block_q4_0x8 interleaved format (from quantizer).
-          // First unpack to standard block_q4_0, then repack to x4x2.
-          size_t nblocks = K / QK4_0;
-          size_t data_size_x8 = (N / 8) * nblocks * sizeof(block_q4_0x8);
-          std::vector<uint8_t> unpacked_q4_0(N * nblocks * sizeof(block_q4_0));
-          Q4_0Utils::unpackBlocksQ4_0x8(
-            reinterpret_cast<const block_q4_0x8 *>(mdata), data_size_x8, N, K,
-            reinterpret_cast<block_q4_0 *>(unpacked_q4_0.data()));
-
-          // Repack block_q4_0 weights to x4x2 row-strided format
+          // Directly convert to x4x2 row-strided format for DSP.
           size_t row_stride = (size_t)(K / 2) + (size_t)(K / 256) * 16;
           size_t wt_size = (size_t)N * row_stride;
           std::vector<uint8_t> weight_x4x2(wt_size, 0);
           size_t actual_stride = 0;
-          Q4_0Utils::repackToX4x2_Q4_0(
-            reinterpret_cast<const block_q4_0 *>(unpacked_q4_0.data()),
+          Q4_0Utils::repackToX4x2_Q4_0x8(
+            reinterpret_cast<const block_q4_0x8 *>(mdata),
             weight_x4x2.data(), N, K, &actual_stride);
 
           size_t act_size = M * K * sizeof(float);

--- a/nntrainer/tensor/htp_backend/htp/commu.c
+++ b/nntrainer/tensor/htp_backend/htp/commu.c
@@ -459,15 +459,16 @@ AEEResult htp_ops_mat_mul_af32_pwqk0_of32(remote_handle64 handle, int32 output_f
   const float  *activation = (const float *) (p1 + activation_offset);
   const uint8_t *weight     = (const uint8_t *) (p2 + weight_offset);
 
-  size_t output_size     = m * n * sizeof(float);
-  size_t activation_size = m * k * sizeof(float);
-  size_t weight_size     = (size_t)k * n / QK_K * sizeof(my_block_q4_0);
+  size_t weight_row_stride = compute_x4x2_row_stride(k, GGML_TYPE_Q4_0);
+  size_t output_size       = m * n * sizeof(float);
+  size_t activation_size   = m * k * sizeof(float);
+  size_t weight_size       = (size_t)n * weight_row_stride;
 
   qurt_mem_cache_clean((qurt_addr_t) activation, activation_size, QURT_MEM_CACHE_INVALIDATE, QURT_MEM_DCACHE);
   qurt_mem_cache_clean((qurt_addr_t) weight, weight_size, QURT_MEM_CACHE_INVALIDATE, QURT_MEM_DCACHE);
 
   hmx_manager_enable_execution();
-  err = hmx_mat_mul_af32_pwqk0_of32(output, activation, weight, m, k, n, GGML_TYPE_Q4_0);
+  err = hmx_mat_mul_af32_pwqk0_of32(output, activation, weight, m, k, n, weight_row_stride, GGML_TYPE_Q4_0);
   hmx_manager_disable_execution();
 
   qurt_mem_cache_clean((qurt_addr_t) output, output_size, QURT_MEM_CACHE_FLUSH, QURT_MEM_DCACHE);

--- a/nntrainer/tensor/htp_backend/htp/hmx_ops/mat_mul.c
+++ b/nntrainer/tensor/htp_backend/htp/hmx_ops/mat_mul.c
@@ -43,17 +43,6 @@ static inline void swap_ptr(void **p1, void **p2) {
   *p2     = t;
 }
 
-static inline size_t get_super_block_size(enum ggml_type weight_type) {
-  switch (weight_type) {
-    case GGML_TYPE_Q4_0:
-    case GGML_TYPE_IQ4_NL:
-      return sizeof(my_block_q4_0);
-    case GGML_TYPE_Q8_0:
-      return sizeof(my_block_q8_0);
-    default:
-      return 0;
-  }
-}
 
 static inline int dma_issue_load_from_ddr(dma_desc_1d_t *desc, void *vtcm_dst, const void *src, size_t size) {
   dma_wait_for_idle();

--- a/nntrainer/tensor/htp_backend/htp/hmx_ops/mat_mul.c
+++ b/nntrainer/tensor/htp_backend/htp/hmx_ops/mat_mul.c
@@ -71,6 +71,29 @@ static inline int dma_issue_load_from_ddr(dma_desc_1d_t *desc, void *vtcm_dst, c
   return dma_submit_one(desc);
 }
 
+static inline int dma_issue_load_2d(dma_desc_2d_t *desc, void *vtcm_dst, const void *src, uint16_t roi_width,
+                                    uint16_t roi_height, uint16_t src_stride, uint16_t dst_stride) {
+  dma_wait_for_idle();
+
+  desc->next             = 0;
+  desc->length           = 0;
+  desc->type             = DMA_DESC_TYPE_2D;
+  desc->src_bypass       = 1;
+  desc->dst_bypass       = 0;
+  desc->ordered          = 1;
+  desc->dstate           = DMA_DESC_DSTATE_PENDING;
+  desc->src              = (uint32_t) src;
+  desc->dst              = (uint32_t) vtcm_dst;
+  desc->roi_width        = roi_width;
+  desc->roi_height       = roi_height;
+  desc->src_stride       = src_stride;
+  desc->dst_stride       = dst_stride;
+  desc->src_width_offset = 0;
+  desc->dst_width_offset = 0;
+
+  return dma_submit_one((dma_desc_1d_t *) desc);
+}
+
 static void find_chunk_size(size_t x_max, size_t y_max, size_t xy_max, size_t x_unit, size_t y_unit, size_t *x_out,
                             size_t *y_out) {
   int64_t best_xy = 0;
@@ -696,15 +719,327 @@ void dequantize_common_weight_chunk_qk_0_to_fp16_hvx(__fp16 *vtcm_dst, const voi
   worker_pool_synctoken_wait(&(state.sync_ctx));
 }
 
+// ==================== x4x2 dequantization kernels ====================
+
+// Scatter offsets for writing 2 rows of 32 FP16 values into HMX tile layout.
+// Each element is an offset (in bytes) within the 2KB tile for one FP16 element.
+// 16 valid entries (one per pair of rows), 16 zero-padding entries.
+static const int32_t weight_transpose_scatter_offsets[32] __attribute__((aligned(VLEN))) = {
+  0 * 128, 1 * 128, 2 * 128,  3 * 128,  4 * 128,  5 * 128,  6 * 128,  7 * 128,
+  8 * 128, 9 * 128, 10 * 128, 11 * 128, 12 * 128, 13 * 128, 14 * 128, 15 * 128,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+};
+
+// Dequantize a single Q4_0 group (32 elements) from x4x2 format.
+// packed_quants: pointer to 128-byte packed quants block within the row
+// upper: if true, extract high nibbles; otherwise low nibbles
+// scale_ptr: pointer to the FP16 scale for this group
+// vlut_cvt: LUT vector for INT4->FP16 conversion
+// Returns: HVX vector with 32 dequantized FP16 values (in lower 64 bytes)
+static inline HVX_Vector dequantize_x4x2_q4_0_group_hvx(const uint8_t *packed_quants, bool upper,
+                                                         const __fp16 *scale_ptr, HVX_Vector vlut_cvt) {
+  HVX_Vector vq = vmemu(packed_quants);
+
+  // Extract the relevant nibble (lower or upper 4 bits)
+  HVX_Vector v_nibbles;
+  if (upper) {
+    v_nibbles = Q6_Vub_vlsr_VubR(vq, 4);
+  } else {
+    v_nibbles = vq;  // vlut16 only looks at low 4 bits per byte
+  }
+
+  // LUT conversion: INT4 -> FP16 (32 values)
+  HVX_VectorPair vp_q = Q6_Wh_vlut16_VbVhR_nomatch(v_nibbles, vlut_cvt, 0);
+  HVX_Vector v_quants_hf = Q6_V_lo_W(vp_q);
+
+  // Broadcast scale to all 32 positions
+  HVX_Vector v_scale_raw = vmemu(scale_ptr);
+  HVX_Vector v_scale = Q6_V_lo_W(Q6_Wh_vlut16_VbVhR_nomatch(Q6_V_vzero(), v_scale_raw, 0));
+
+  // Dequantize: quant * scale
+  return Q6_Vhf_equals_Vqf16(Q6_Vqf16_vmpy_VhfVhf(v_quants_hf, v_scale));
+}
+
+// Dequantize 4 consecutive Q4_0 groups from x4x2 format (fast path).
+// packed_quants: pointer to the 128-byte packed quants for these 4 groups
+// upper: if true, extract high nibbles
+// scale_ptr: pointer to 4 consecutive FP16 scales
+// vlut_cvt: LUT for INT4->FP16
+// out[4]: output array of 4 HVX vectors, each with 32 FP16 values
+static inline void dequantize_x4x2_q4_0_x4groups_hvx(const uint8_t *packed_quants, bool upper,
+                                                      const __fp16 *scale_ptr, HVX_Vector vlut_cvt,
+                                                      HVX_Vector out[4]) {
+  HVX_Vector vq = vmemu(packed_quants);
+
+  HVX_Vector v_nibbles;
+  if (upper) {
+    v_nibbles = Q6_Vub_vlsr_VubR(vq, 4);
+  } else {
+    v_nibbles = vq;
+  }
+
+  // Single vlut16 covers all 128 bytes → 4 groups of 32 FP16 values
+  HVX_VectorPair vp_q0 = Q6_Wh_vlut16_VbVhR_nomatch(v_nibbles, vlut_cvt, 0);
+
+  // Load all 4 scales and broadcast
+  HVX_Vector v_packed_scales = vmemu(scale_ptr);
+  HVX_Vector vlut_scales = Q6_V_lo_W(Q6_Wuw_vunpack_Vuh(v_packed_scales));
+
+  // Scale index lookup tables for 4 groups
+  static const uint8_t scale_idx_data_lo[128] __attribute__((aligned(VLEN))) = {
+    0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2,
+    0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2,
+    1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3,
+    1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3,
+  };
+  HVX_Vector vlut_scales_idx0 = vmem(scale_idx_data_lo);
+  HVX_Vector vlut_scales_idx1 = Q6_Vb_vadd_VbVb(vlut_scales_idx0, Q6_Vb_vsplat_R(4));
+
+  HVX_VectorPair vp_s0 = Q6_Wh_vlut16_VbVhR_nomatch(vlut_scales_idx0, vlut_scales, 0);
+  HVX_VectorPair vp_s1 = Q6_Wh_vlut16_VbVhR_nomatch(vlut_scales_idx1, vlut_scales, 0);
+
+  out[0] = Q6_Vhf_equals_Vqf16(Q6_Vqf16_vmpy_VhfVhf(Q6_V_lo_W(vp_q0), Q6_V_lo_W(vp_s0)));
+  out[1] = Q6_Vhf_equals_Vqf16(Q6_Vqf16_vmpy_VhfVhf(Q6_V_hi_W(vp_q0), Q6_V_hi_W(vp_s0)));
+
+  // For groups 2-3, we need the high part of the vlut16 result
+  HVX_VectorPair vp_q1 = Q6_Wh_vlut16_VbVhR_nomatch(Q6_Vub_vlsr_VubR(vq, 4), vlut_cvt, 0);
+  if (!upper) {
+    vp_q1 = Q6_Wh_vlut16_VbVhR_nomatch(v_nibbles, vlut_cvt, 0);
+  }
+
+  out[2] = Q6_Vhf_equals_Vqf16(Q6_Vqf16_vmpy_VhfVhf(Q6_V_lo_W(vp_s1), Q6_V_lo_W(vp_s1)));
+  out[3] = Q6_Vhf_equals_Vqf16(Q6_Vqf16_vmpy_VhfVhf(Q6_V_hi_W(vp_s1), Q6_V_hi_W(vp_s1)));
+
+  // Correct: actually multiply quants by scales
+  out[2] = Q6_Vhf_equals_Vqf16(Q6_Vqf16_vmpy_VhfVhf(Q6_V_lo_W(vp_q1), Q6_V_lo_W(vp_s1)));
+  out[3] = Q6_Vhf_equals_Vqf16(Q6_Vqf16_vmpy_VhfVhf(Q6_V_hi_W(vp_q1), Q6_V_hi_W(vp_s1)));
+}
+
+// Dequantize a single Q8_0 group (32 elements) from x4x2 format.
+static inline HVX_Vector dequantize_x4x2_q8_0_group_hvx(const int8_t *quants, const __fp16 *scale_ptr) {
+  HVX_Vector vq = vmemu(quants);
+
+  // int8 -> FP16: sign-extend to int16, then convert to FP16
+  HVX_Vector v0 = Q6_V_lo_W(Q6_Wh_vunpack_Vb(vq));
+  HVX_Vector v_quants_hf = Q6_Vhf_equals_Vh(v0);
+
+  // Broadcast scale
+  HVX_Vector v_scale_raw = vmemu(scale_ptr);
+  HVX_Vector v_scale = Q6_V_lo_W(Q6_Wh_vlut16_VbVhR_nomatch(Q6_V_vzero(), v_scale_raw, 0));
+
+  return Q6_Vhf_equals_Vqf16(Q6_Vqf16_vmpy_VhfVhf(v_quants_hf, v_scale));
+}
+
+// Main x4x2 tile-based dequantization task.
+// Processes tiles [start_tile, end_tile) and writes dequantized FP16 data
+// directly into HMX tile layout using vscatter.
+static void dequantize_x4x2_weight_to_fp16_tiles_task(__fp16 *restrict vtcm_dst, const uint8_t *restrict vtcm_src,
+                                                      int n_cols, int k_block, size_t row_stride,
+                                                      enum ggml_type weight_type, int start_tile, int end_tile) {
+  const int n_k_tiles = k_block / HMX_FP16_TILE_N_COLS;
+  const int qrow_size = (weight_type == GGML_TYPE_Q8_0) ? k_block : (k_block / 2);
+
+  const HVX_Vector vlut_cvt = (weight_type == GGML_TYPE_IQ4_NL) ? vmem(iq4_nl_to_fp16_lut) : vmem(q4_0_to_fp16_lut);
+
+  const HVX_Vector v_scat_base = vmem(weight_transpose_scatter_offsets);
+  const HVX_Vector v_scat_step = Q6_V_vsplat_R(4);  // 4 bytes per FP16 pair offset increment
+  const HVX_VectorPred q_mask64 = Q6_Q_vsetq_R(64);  // mask for 32 FP16 elements = 64 bytes
+
+  for (int t = start_tile; t < end_tile; ) {
+    int ct = t / n_k_tiles;  // column tile index (N dimension)
+    int kt = t % n_k_tiles;  // k tile index (K dimension)
+
+    // Q4_0/IQ4_NL: 4-tile batch fast path
+    if ((weight_type == GGML_TYPE_Q4_0 || weight_type == GGML_TYPE_IQ4_NL) && (kt % 4 == 0) &&
+        (t + 4 <= end_tile) && ((t + 3) / n_k_tiles == ct)) {
+      int  blk_idx      = (kt * 32) / QK_Q4_0x4x2;
+      int  sub_blk_base = ((kt * 32) % QK_Q4_0x4x2) / 32;
+      bool upper        = (sub_blk_base >= 4);
+      int  packed_off   = blk_idx * (QK_Q4_0x4x2 / 2);
+      int  scale_off    = qrow_size + blk_idx * HMX_X4X2_DBLK_SIZE + sub_blk_base * (int) sizeof(__fp16);
+
+      __fp16 *tile_bases[4];
+      for (int g = 0; g < 4; g++) {
+        tile_bases[g] = vtcm_dst + (t + g) * HMX_FP16_TILE_N_ELMS;
+      }
+
+      HVX_Vector v_off = v_scat_base;
+      for (int r = 0; r < HMX_FP16_TILE_N_ROWS; r += 2) {
+        int row0 = ct * HMX_FP16_TILE_N_COLS + r;
+        int row1 = row0 + 1;
+        const uint8_t *r0 = vtcm_src + row0 * row_stride;
+        const uint8_t *r1 = vtcm_src + row1 * row_stride;
+
+        HVX_Vector v0[4], v1[4];
+        dequantize_x4x2_q4_0_x4groups_hvx(r0 + packed_off, upper, (const __fp16 *) (r0 + scale_off), vlut_cvt, v0);
+        if (row1 < n_cols) {
+          dequantize_x4x2_q4_0_x4groups_hvx(r1 + packed_off, upper, (const __fp16 *) (r1 + scale_off), vlut_cvt, v1);
+        } else {
+          v1[0] = v1[1] = v1[2] = v1[3] = Q6_V_vzero();
+        }
+
+        for (int g = 0; g < 4; g++) {
+          Q6_vscatter_QRMVwV(q_mask64, (size_t) tile_bases[g], HMX_FP16_TILE_SIZE - 1, v_off, v0[g]);
+        }
+        v_off = Q6_Vw_vadd_VwVw(v_off, v_scat_step);
+        for (int g = 0; g < 4; g++) {
+          Q6_vscatter_QRMVwV(q_mask64, (size_t) tile_bases[g], HMX_FP16_TILE_SIZE - 1, v_off, v1[g]);
+        }
+        v_off = Q6_Vw_vadd_VwVw(v_off, v_scat_step);
+      }
+
+      // drain scatter buffer
+      for (int g = 0; g < 4; g++) {
+        (void) *(volatile HVX_Vector *) (tile_bases[g]);
+      }
+
+      t += 4;
+      continue;
+    }
+
+    // Single-tile fallback for Q4_0/IQ4_NL
+    __fp16 *tile_base = vtcm_dst + t * HMX_FP16_TILE_N_ELMS;
+
+    if (weight_type == GGML_TYPE_Q4_0 || weight_type == GGML_TYPE_IQ4_NL) {
+      int  blk_idx  = (kt * 32) / QK_Q4_0x4x2;
+      int  sub_blk  = ((kt * 32) % QK_Q4_0x4x2) / 32;
+      bool upper    = (sub_blk >= 4);
+      int  byte_off = blk_idx * (QK_Q4_0x4x2 / 2) + (upper ? (sub_blk - 4) : sub_blk) * 32;
+      int  scale_off = qrow_size + blk_idx * HMX_X4X2_DBLK_SIZE + sub_blk * (int) sizeof(__fp16);
+
+      HVX_Vector v_off = v_scat_base;
+      for (int r = 0; r < HMX_FP16_TILE_N_ROWS; r += 2) {
+        int row0 = ct * HMX_FP16_TILE_N_COLS + r;
+        int row1 = row0 + 1;
+
+        const uint8_t *r0 = vtcm_src + row0 * row_stride;
+        const uint8_t *r1 = vtcm_src + row1 * row_stride;
+
+        HVX_Vector v0 =
+          dequantize_x4x2_q4_0_group_hvx(r0 + byte_off, upper, (const __fp16 *) (r0 + scale_off), vlut_cvt);
+        HVX_Vector v1 = (row1 < n_cols)
+                           ? dequantize_x4x2_q4_0_group_hvx(r1 + byte_off, upper, (const __fp16 *) (r1 + scale_off),
+                                                             vlut_cvt)
+                           : Q6_V_vzero();
+
+        Q6_vscatter_QRMVwV(q_mask64, (size_t) tile_base, HMX_FP16_TILE_SIZE - 1, v_off, v0);
+        v_off = Q6_Vw_vadd_VwVw(v_off, v_scat_step);
+        Q6_vscatter_QRMVwV(q_mask64, (size_t) tile_base, HMX_FP16_TILE_SIZE - 1, v_off, v1);
+        v_off = Q6_Vw_vadd_VwVw(v_off, v_scat_step);
+      }
+      (void) *(volatile HVX_Vector *) (tile_base);
+    } else if (weight_type == GGML_TYPE_Q8_0) {
+      int blk_idx   = (kt * 32) / QK_Q8_0x4x2;
+      int sub_blk   = ((kt * 32) % QK_Q8_0x4x2) / 32;
+      int byte_off  = blk_idx * QK_Q8_0x4x2 + sub_blk * 32;
+      int scale_off = qrow_size + blk_idx * HMX_X4X2_DBLK_SIZE + sub_blk * (int) sizeof(__fp16);
+
+      HVX_Vector v_off = v_scat_base;
+      for (int r = 0; r < HMX_FP16_TILE_N_ROWS; r += 2) {
+        int row0 = ct * HMX_FP16_TILE_N_COLS + r;
+        int row1 = row0 + 1;
+
+        const uint8_t *r0 = vtcm_src + row0 * row_stride;
+        const uint8_t *r1 = vtcm_src + row1 * row_stride;
+
+        HVX_Vector v0 = dequantize_x4x2_q8_0_group_hvx((const int8_t *) (r0 + byte_off),
+                                                         (const __fp16 *) (r0 + scale_off));
+        HVX_Vector v1 =
+          (row1 < n_cols)
+            ? dequantize_x4x2_q8_0_group_hvx((const int8_t *) (r1 + byte_off), (const __fp16 *) (r1 + scale_off))
+            : Q6_V_vzero();
+
+        Q6_vscatter_QRMVwV(q_mask64, (size_t) tile_base, HMX_FP16_TILE_SIZE - 1, v_off, v0);
+        v_off = Q6_Vw_vadd_VwVw(v_off, v_scat_step);
+        Q6_vscatter_QRMVwV(q_mask64, (size_t) tile_base, HMX_FP16_TILE_SIZE - 1, v_off, v1);
+        v_off = Q6_Vw_vadd_VwVw(v_off, v_scat_step);
+      }
+      (void) *(volatile HVX_Vector *) (tile_base);
+    }
+    ++t;
+  }
+
+  // final drain
+  if (start_tile < end_tile) {
+    (void) *(volatile HVX_Vector *) (vtcm_dst + (end_tile - 1) * HMX_FP16_TILE_N_ELMS);
+  }
+}
+
+// Task state for x4x2 dequantization worker
+typedef struct {
+  EXPAND_COMMON_TASK_STATE_MEMBERS
+  __fp16        *dst;
+  const uint8_t *src;
+  int            n_cols;
+  int            k_block;
+  size_t         row_stride;
+  enum ggml_type weight_type;
+} x4x2_dequantize_task_state_t;
+
+static void dequantize_x4x2_worker_loop(void *data, int _worker_index) {
+  (void) _worker_index;
+  x4x2_dequantize_task_state_t *state = (x4x2_dequantize_task_state_t *) data;
+
+  while (1) {
+    unsigned int task_id = worker_pool_atomic_inc_return(&(state->task_id)) - 1;
+    if (task_id >= state->n_tasks) {
+      break;
+    }
+
+    int start_tile = task_id * state->n_chunks_per_task;
+    int end_tile   = smin(start_tile + state->n_chunks_per_task, state->n_tot_chunks);
+
+    dequantize_x4x2_weight_to_fp16_tiles_task(state->dst, state->src, state->n_cols, state->k_block,
+                                               state->row_stride, state->weight_type, start_tile, end_tile);
+  }
+
+  worker_pool_synctoken_jobdone(&(state->sync_ctx));
+}
+
+// Multi-threaded x4x2 dequantization: distributes tile range across HVX workers
+void dequantize_x4x2_weight_chunk_to_fp16_tiles(__fp16 *vtcm_dst, const void *vtcm_src, int n_cols, int k_block,
+                                                 size_t row_stride, enum ggml_type weight_type) {
+  assert(n_cols % HMX_FP16_TILE_N_COLS == 0);
+  assert(k_block % HMX_FP16_TILE_N_COLS == 0);
+
+  int n_col_tiles = n_cols / HMX_FP16_TILE_N_COLS;
+  int n_k_tiles   = k_block / HMX_FP16_TILE_N_COLS;
+  int n_tot_tiles = n_col_tiles * n_k_tiles;
+
+  int    n_workers         = num_hvx128_contexts;
+  size_t n_tiles_per_task  = ceil_div(n_tot_tiles, n_workers);
+
+  x4x2_dequantize_task_state_t state;
+  INIT_COMMON_TASK_STATE_MEMBERS(state, n_tot_tiles, n_tiles_per_task);
+  state.dst         = vtcm_dst;
+  state.src         = (const uint8_t *) vtcm_src;
+  state.n_cols      = n_cols;
+  state.k_block     = k_block;
+  state.row_stride  = row_stride;
+  state.weight_type = weight_type;
+
+  worker_pool_job_t job;
+  job.fptr = dequantize_x4x2_worker_loop;
+  job.dptr = &state;
+
+  worker_pool_synctoken_init(&(state.sync_ctx), n_workers);
+  for (int i = 0; i < n_workers; ++i) {
+    worker_pool_submit(NULL, job);
+  }
+  worker_pool_synctoken_wait(&(state.sync_ctx));
+}
+
+// ==================== end x4x2 dequantization ====================
+
 static void core_dot_chunk_fp16(__fp16 *output, const __fp16 *activation, const __fp16 *weight, const __fp16 *scales,
                                 int n_row_tiles, int n_col_tiles, int n_dot_tiles) {
   hmx_unit_acquire();
-
-  asm volatile("mxclracc.hf");
   hmx_set_output_scales(scales);
 
   for (int r = 0; r < n_row_tiles; ++r) {
     for (int c = 0; c < n_col_tiles; ++c) {
+      asm volatile("mxclracc.hf");  // clear accumulator per output tile
+
       const __fp16 *row_tiles = activation + r * n_dot_tiles * HMX_FP16_TILE_N_ELMS;
       const __fp16 *col_tiles = weight + c * n_dot_tiles * HMX_FP16_TILE_N_ELMS;
 
@@ -930,11 +1265,11 @@ static void core_dot_fp16_hmx_worker_fn(void *data, int _worker_index) {
 }
 
 int mat_mul_af32_pwqk0_of32_stationary(float *restrict out, const float *restrict x, const uint8_t *restrict w, int m,
-                                       int k, int n, enum ggml_type w_type);
+                                       int k, int n, size_t weight_row_stride, enum ggml_type w_type);
 
 int hmx_mat_mul_af32_pwqk0_of32(float *restrict dst, const float *restrict activation,
                                      const uint8_t *restrict permuted_weight, int m, int k, int n,
-                                     enum ggml_type weight_type) {
+                                     size_t weight_row_stride, enum ggml_type weight_type) {
   if (!dst || !activation || !permuted_weight || !m || !n || !k) {
     return -1;
   }
@@ -946,13 +1281,13 @@ int hmx_mat_mul_af32_pwqk0_of32(float *restrict dst, const float *restrict activ
     return -1;
   }
 
-  // for large m, k (e.g. prefill FFN Down), use out-staionary version
+  // for large m, k (e.g. prefill FFN Down), use out-stationary version
   if (m >= 128 && k > n && n > 1024) {
-    return mat_mul_af32_pwqk0_of32_stationary(dst, activation, permuted_weight, m, k, n, weight_type);
+    return mat_mul_af32_pwqk0_of32_stationary(dst, activation, permuted_weight, m, k, n, weight_row_stride,
+                                               weight_type);
   }
 
-  size_t super_block_size = get_super_block_size(weight_type);
-  if (super_block_size == 0) {
+  if (weight_row_stride == 0) {
     return -1;
   }
 
@@ -1010,15 +1345,15 @@ int hmx_mat_mul_af32_pwqk0_of32(float *restrict dst, const float *restrict activ
       void *buf_curr = vtcm_scratch0;
       void *buf_next = vtcm_scratch1;
 
-      static dma_desc_1d_t desc
+      static dma_desc_2d_t desc_2d
         __attribute__((aligned(64)));  // NOTE(hzx): make sure the DMA descriptor's lifetime is long enough
 
-      // issue async DDR data transfer for the first weight chunk
+      // issue async 2D DMA transfer for the first weight chunk (x4x2 row-strided format)
       {
-        const size_t n_cols_first            = smin(n, n_chunk_n_cols);
-        const size_t first_weight_chunk_size = n_cols_first * k / QK_K * super_block_size;
+        const size_t n_cols_first = smin(n, n_chunk_n_cols);
 
-        dma_issue_load_from_ddr(&desc, buf_curr, permuted_weight, first_weight_chunk_size);
+        dma_issue_load_2d(&desc_2d, buf_curr, permuted_weight, (uint16_t) weight_row_stride,
+                          (uint16_t) n_cols_first, (uint16_t) weight_row_stride, (uint16_t) weight_row_stride);
       }
 
       for (size_t nc = 0; nc < n; nc += n_chunk_n_cols) {
@@ -1030,17 +1365,15 @@ int hmx_mat_mul_af32_pwqk0_of32(float *restrict dst, const float *restrict activ
 
           const size_t nc_next = nc + n_chunk_n_cols;
           if (nc_next < n) {
-            const size_t n_cols_next = smin(n - nc_next, n_chunk_n_cols);
+            const size_t   n_cols_next        = smin(n - nc_next, n_chunk_n_cols);
+            const uint8_t *next_weight_chunk  = permuted_weight + nc_next * weight_row_stride;
 
-            const size_t   next_weight_chunk_size = n_cols_next * k / QK_K * super_block_size;
-            const uint8_t *next_weight_chunk      = permuted_weight + nc_next * k / QK_K * super_block_size;
-
-            dma_issue_load_from_ddr(&desc, buf_next, next_weight_chunk, next_weight_chunk_size);
+            dma_issue_load_2d(&desc_2d, buf_next, next_weight_chunk, (uint16_t) weight_row_stride,
+                              (uint16_t) n_cols_next, (uint16_t) weight_row_stride, (uint16_t) weight_row_stride);
           }
 
-          const uint8_t *permuted_weight_chunk = permuted_weight + (nc * k / QK_K) * super_block_size;
-          dequantize_permuted_weight_chunk_qk_0_to_fp16_hvx(vtcm_weight, permuted_weight_chunk, n_cols * k, k,
-                                                            weight_type, buf_curr);
+          // x4x2 tile-based dequantization with vscatter
+          dequantize_x4x2_weight_chunk_to_fp16_tiles(vtcm_weight, buf_curr, n_cols, k, weight_row_stride, weight_type);
 
           swap_ptr(&buf_curr, &buf_next);
         }
@@ -1081,7 +1414,7 @@ int hmx_mat_mul_af32_pwqk0_of32(float *restrict dst, const float *restrict activ
     // MM ||    C2    ||
     // ST || D1 |     ||
 
-    static dma_desc_1d_t _Alignas(64) dma_desc;
+    static dma_desc_2d_t _Alignas(64) dma_desc;
     static core_dot_fp16_task_state_t mm_task_state;
     static worker_pool_job_t          mm_task_job;
 
@@ -1096,13 +1429,12 @@ int hmx_mat_mul_af32_pwqk0_of32(float *restrict dst, const float *restrict activ
       void *vtcm_weight_bufs[2] = { vtcm_scratch0, vtcm_scratch1 };
       void *vtcm_output_bufs[2] = { vtcm_output, vtcm_scratch2 };
 
-      // prologue: A0
+      // prologue: A0 (2D DMA load for x4x2 format)
       const size_t n_cols_A0 = smin(n - 0 * n_chunk_n_cols, n_chunk_n_cols);
       {
-        const size_t chunk_size_A0 = n_cols_A0 * k / QK_K * super_block_size;
-
         const uint8_t *qweight_chunk_A0 = permuted_weight;
-        dma_issue_load_from_ddr(&dma_desc, vtcm_qweight, qweight_chunk_A0, chunk_size_A0);
+        dma_issue_load_2d(&dma_desc, vtcm_qweight, qweight_chunk_A0, (uint16_t) weight_row_stride,
+                          (uint16_t) n_cols_A0, (uint16_t) weight_row_stride, (uint16_t) weight_row_stride);
       }
 
       {
@@ -1112,18 +1444,17 @@ int hmx_mat_mul_af32_pwqk0_of32(float *restrict dst, const float *restrict activ
 
       // prologue: B0, A1, C0, B1
       {
-        // B0
+        // B0: x4x2 tile-based dequantization
         dma_wait_for_idle();
-        dequantize_permuted_weight_chunk_qk_0_to_fp16_hvx(vtcm_weight_bufs[0], NULL, n_cols_A0 * k, k, weight_type,
-                                                          vtcm_qweight);
+        dequantize_x4x2_weight_chunk_to_fp16_tiles(vtcm_weight_bufs[0], vtcm_qweight, n_cols_A0, k, weight_row_stride,
+                                                    weight_type);
 
         // A1
         const size_t n_cols_A1 = smin(n - 1 * n_chunk_n_cols, n_chunk_n_cols);
         if (1 < n_chunk_cnt) {
-          const size_t chunk_size_A1 = n_cols_A1 * k / QK_K * super_block_size;
-
-          const uint8_t *qweight_chunk_A1 = permuted_weight + n_chunk_n_cols * k / QK_K * super_block_size;
-          dma_issue_load_from_ddr(&dma_desc, vtcm_qweight, qweight_chunk_A1, chunk_size_A1);
+          const uint8_t *qweight_chunk_A1 = permuted_weight + n_chunk_n_cols * weight_row_stride;
+          dma_issue_load_2d(&dma_desc, vtcm_qweight, qweight_chunk_A1, (uint16_t) weight_row_stride,
+                            (uint16_t) n_cols_A1, (uint16_t) weight_row_stride, (uint16_t) weight_row_stride);
         }
 
         // C0
@@ -1143,11 +1474,11 @@ int hmx_mat_mul_af32_pwqk0_of32(float *restrict dst, const float *restrict activ
           worker_pool_submit(hmx_worker_pool_ctx, mm_task_job);
         }
 
-        // B1
+        // B1: x4x2 tile-based dequantization
         if (1 < n_chunk_cnt) {
           dma_wait_for_idle();
-          dequantize_permuted_weight_chunk_qk_0_to_fp16_hvx(vtcm_weight_bufs[1], NULL, n_cols_A1 * k, k, weight_type,
-                                                            vtcm_qweight);
+          dequantize_x4x2_weight_chunk_to_fp16_tiles(vtcm_weight_bufs[1], vtcm_qweight, n_cols_A1, k,
+                                                      weight_row_stride, weight_type);
         }
       }
 
@@ -1161,11 +1492,11 @@ int hmx_mat_mul_af32_pwqk0_of32(float *restrict dst, const float *restrict activ
         const size_t n_cols_p1 = smin(n - nc_p1, n_chunk_n_cols);
         const size_t n_cols_p2 = smin(n - nc_p2, n_chunk_n_cols);
 
-        // issue A_{i+2}
+        // issue A_{i+2} (2D DMA)
         if (i + 2 < n_chunk_cnt) {
-          const size_t   chunk_size_p2    = n_cols_p2 * k / QK_K * super_block_size;
-          const uint8_t *qweight_chunk_p2 = permuted_weight + nc_p2 * k / QK_K * super_block_size;
-          dma_issue_load_from_ddr(&dma_desc, vtcm_qweight, qweight_chunk_p2, chunk_size_p2);
+          const uint8_t *qweight_chunk_p2 = permuted_weight + nc_p2 * weight_row_stride;
+          dma_issue_load_2d(&dma_desc, vtcm_qweight, qweight_chunk_p2, (uint16_t) weight_row_stride,
+                            (uint16_t) n_cols_p2, (uint16_t) weight_row_stride, (uint16_t) weight_row_stride);
         }
 
         // wait for HMX (C_{i})
@@ -1197,8 +1528,8 @@ int hmx_mat_mul_af32_pwqk0_of32(float *restrict dst, const float *restrict activ
         // wait for DMA (A_{i+2}), compute B_{i+2}
         if (i + 2 < n_chunk_cnt) {
           dma_wait_for_idle();
-          dequantize_permuted_weight_chunk_qk_0_to_fp16_hvx(vtcm_weight_bufs[(i + 2) % 2], NULL, n_cols_p2 * k, k,
-                                                            weight_type, vtcm_qweight);
+          dequantize_x4x2_weight_chunk_to_fp16_tiles(vtcm_weight_bufs[(i + 2) % 2], vtcm_qweight, n_cols_p2, k,
+                                                      weight_row_stride, weight_type);
         }
       }
     }
@@ -1357,12 +1688,11 @@ void transfer_activation_chunk_multithread(__fp16 *dst, const float *src, int n_
 }
 
 int mat_mul_af32_pwqk0_of32_stationary(float *restrict out, const float *restrict x, const uint8_t *restrict w, int m,
-                                       int k, int n, enum ggml_type weight_type) {
+                                       int k, int n, size_t weight_row_stride, enum ggml_type weight_type) {
   // NOTE(hzx): this constraint on k originates from 2D DMA, consider alternative ways to load activation
   assert(k < 16384);
   // assume k % 32 == 0 && n % 32 == 0
-  const size_t super_block_size = get_super_block_size(weight_type);
-  if (super_block_size == 0) {
+  if (weight_row_stride == 0) {
     return -1;
   }
 
@@ -1447,20 +1777,20 @@ int mat_mul_af32_pwqk0_of32_stationary(float *restrict out, const float *restric
           dma_wait_for_idle();
         }
 
-        // fetch weight block into VTCM
+        // fetch weight block into VTCM (x4x2 row-strided format via 2D DMA)
         {
+          // In x4x2 format, weight for column nc, k-offset kk:
+          // Each row starts at w + row_idx * weight_row_stride
+          // We need n_blk_sz rows, starting from row nc
+          // Within each row, we need the k-range [kk, kk+k_blk_sz)
+          // For simplicity, fetch entire rows and let dequant handle sub-ranges
           qweight_fetch_task_state_t *s = &fetch_task_state;
 
-          size_t width_ne  = HMX_FP16_TILE_N_COLS * k_blk_sz;
-          size_t stride_ne = HMX_FP16_TILE_N_COLS * k;
-          size_t width     = width_ne / QK_K * super_block_size;
-          size_t stride    = stride_ne / QK_K * super_block_size;
-
           s->dst    = vtcm_scratch0;
-          s->src    = w + (nc * k + HMX_FP16_TILE_N_COLS * kk) / QK_K * super_block_size;
-          s->height = n_col_tiles;
-          s->width  = width;
-          s->stride = stride;
+          s->src    = w + nc * weight_row_stride;
+          s->height = n_blk_sz;
+          s->width  = weight_row_stride;
+          s->stride = weight_row_stride;
 
           worker_pool_synctoken_init(&s->sync_ctx, 1);
           worker_pool_submit(fetch_task_worker_pool_ctx, fetch_task_job);
@@ -1479,12 +1809,11 @@ int mat_mul_af32_pwqk0_of32_stationary(float *restrict out, const float *restric
           transfer_activation_chunk_multithread(vtcm_activation, (float *) vtcm_scratch1, m_blk_sz, k_blk_sz, k_blk_sz);
         }
 
-        // dequantize weight block
+        // dequantize weight block (x4x2 tile-based with vscatter)
         {
-          // vtcm_scratch0 is used to store the qweight chunk
           worker_pool_synctoken_wait(&fetch_task_state.sync_ctx);
-          dequantize_permuted_weight_chunk_qk_0_to_fp16_hvx(vtcm_weight, NULL /*unused*/, n_blk_sz * k_blk_sz,
-                                                            -1 /*unused*/, weight_type, vtcm_scratch0);
+          dequantize_x4x2_weight_chunk_to_fp16_tiles(vtcm_weight, vtcm_scratch0, n_blk_sz, k_blk_sz,
+                                                      weight_row_stride, weight_type);
         }
         t_b += HAP_perf_get_qtimer_count() - t1;
 

--- a/nntrainer/tensor/htp_backend/htp/hmx_ops/mat_mul.c
+++ b/nntrainer/tensor/htp_backend/htp/hmx_ops/mat_mul.c
@@ -726,11 +726,16 @@ void dequantize_common_weight_chunk_qk_0_to_fp16_hvx(__fp16 *vtcm_dst, const voi
 // x4x2 row layout for Q8_0:
 //   [quants: K bytes | scale_blocks: (K/256)*16 bytes]
 //   Each group's 32 bytes: int8 quants[0..31]
+// k_block:  number of K elements to process in this call
+// k_offset: starting K index within the full row (0 when processing full K)
+// full_k:   total K dimension of the weight matrix (needed for scale offset calculation)
 static void dequantize_x4x2_weight_to_fp16_tiles_task(__fp16 *restrict vtcm_dst, const uint8_t *restrict vtcm_src,
-                                                      int n_cols, int k_block, size_t row_stride,
-                                                      enum ggml_type weight_type, int start_tile, int end_tile) {
+                                                      int n_cols, int k_block, int k_offset, int full_k,
+                                                      size_t row_stride, enum ggml_type weight_type,
+                                                      int start_tile, int end_tile) {
   const int n_k_tiles = k_block / HMX_FP16_TILE_N_COLS;
-  const int qrow_size = (weight_type == GGML_TYPE_Q8_0) ? k_block : (k_block / 2);
+  // Quant region size of the FULL row (before scale blocks)
+  const int full_qrow_size = (weight_type == GGML_TYPE_Q8_0) ? full_k : (full_k / 2);
 
   for (int t = start_tile; t < end_tile; ++t) {
     int ct = t / n_k_tiles;  // N-dimension tile index
@@ -738,18 +743,17 @@ static void dequantize_x4x2_weight_to_fp16_tiles_task(__fp16 *restrict vtcm_dst,
 
     __fp16 *tile = vtcm_dst + t * HMX_FP16_TILE_N_ELMS;
 
-    // Which group within a row does this tile cover?
-    int group_idx  = kt;             // group index (each group = 32 k-elements)
-    int sb_idx     = group_idx / 8;  // super-block index
-    int grp_in_sb  = group_idx % 8;  // group within super-block (0..7)
-    int sub_blk    = grp_in_sb / 4;  // sub-block (0 or 1)
-    int grp_in_sub = grp_in_sb % 4;  // group within sub-block (0..3)
+    // Absolute group index within the full row (accounting for k_offset)
+    int abs_group_idx = (k_offset / 32) + kt;
+    int sb_idx        = abs_group_idx / 8;
+    int grp_in_sb     = abs_group_idx % 8;
+    int sub_blk       = grp_in_sb / 4;
+    int grp_in_sub    = grp_in_sb % 4;
 
     if (weight_type == GGML_TYPE_Q4_0 || weight_type == GGML_TYPE_IQ4_NL) {
-      // Byte offset of this group's 16 packed quant bytes within a row
+      // Byte offsets within the FULL row
       int q_off = sb_idx * 128 + sub_blk * 64 + grp_in_sub * 16;
-      // Byte offset of this group's FP16 scale within a row
-      int s_off = qrow_size + sb_idx * HMX_X4X2_DBLK_SIZE + grp_in_sb * (int) sizeof(__fp16);
+      int s_off = full_qrow_size + sb_idx * HMX_X4X2_DBLK_SIZE + grp_in_sb * (int) sizeof(__fp16);
 
       for (int n_local = 0; n_local < HMX_FP16_TILE_N_COLS; ++n_local) {
         int row = ct * HMX_FP16_TILE_N_COLS + n_local;
@@ -781,7 +785,7 @@ static void dequantize_x4x2_weight_to_fp16_tiles_task(__fp16 *restrict vtcm_dst,
       }
     } else if (weight_type == GGML_TYPE_Q8_0) {
       int q_off = sb_idx * QK_Q8_0x4x2 + grp_in_sb * 32;
-      int s_off = qrow_size + sb_idx * HMX_X4X2_DBLK_SIZE + grp_in_sb * (int) sizeof(__fp16);
+      int s_off = full_qrow_size + sb_idx * HMX_X4X2_DBLK_SIZE + grp_in_sb * (int) sizeof(__fp16);
 
       for (int n_local = 0; n_local < HMX_FP16_TILE_N_COLS; ++n_local) {
         int row = ct * HMX_FP16_TILE_N_COLS + n_local;
@@ -814,6 +818,8 @@ typedef struct {
   const uint8_t *src;
   int            n_cols;
   int            k_block;
+  int            k_offset;
+  int            full_k;
   size_t         row_stride;
   enum ggml_type weight_type;
 } x4x2_dequantize_task_state_t;
@@ -832,15 +838,20 @@ static void dequantize_x4x2_worker_loop(void *data, int _worker_index) {
     int end_tile   = smin(start_tile + state->n_chunks_per_task, state->n_tot_chunks);
 
     dequantize_x4x2_weight_to_fp16_tiles_task(state->dst, state->src, state->n_cols, state->k_block,
-                                               state->row_stride, state->weight_type, start_tile, end_tile);
+                                               state->k_offset, state->full_k, state->row_stride,
+                                               state->weight_type, start_tile, end_tile);
   }
 
   worker_pool_synctoken_jobdone(&(state->sync_ctx));
 }
 
 // Multi-threaded x4x2 dequantization: distributes tile range across HVX workers
+// k_block:  number of K elements to dequantize
+// k_offset: starting K index within the full row (0 for full-K paths)
+// full_k:   total K dimension of the weight matrix
 void dequantize_x4x2_weight_chunk_to_fp16_tiles(__fp16 *vtcm_dst, const void *vtcm_src, int n_cols, int k_block,
-                                                 size_t row_stride, enum ggml_type weight_type) {
+                                                 int k_offset, int full_k, size_t row_stride,
+                                                 enum ggml_type weight_type) {
   assert(n_cols % HMX_FP16_TILE_N_COLS == 0);
   assert(k_block % HMX_FP16_TILE_N_COLS == 0);
 
@@ -857,6 +868,8 @@ void dequantize_x4x2_weight_chunk_to_fp16_tiles(__fp16 *vtcm_dst, const void *vt
   state.src         = (const uint8_t *) vtcm_src;
   state.n_cols      = n_cols;
   state.k_block     = k_block;
+  state.k_offset    = k_offset;
+  state.full_k      = full_k;
   state.row_stride  = row_stride;
   state.weight_type = weight_type;
 
@@ -1215,7 +1228,8 @@ int hmx_mat_mul_af32_pwqk0_of32(float *restrict dst, const float *restrict activ
           }
 
           // x4x2 tile-based dequantization with vscatter
-          dequantize_x4x2_weight_chunk_to_fp16_tiles(vtcm_weight, buf_curr, n_cols, k, weight_row_stride, weight_type);
+          dequantize_x4x2_weight_chunk_to_fp16_tiles(vtcm_weight, buf_curr, n_cols, k, 0, k, weight_row_stride,
+                                                      weight_type);
 
           swap_ptr(&buf_curr, &buf_next);
         }
@@ -1288,8 +1302,8 @@ int hmx_mat_mul_af32_pwqk0_of32(float *restrict dst, const float *restrict activ
       {
         // B0: x4x2 tile-based dequantization
         dma_wait_for_idle();
-        dequantize_x4x2_weight_chunk_to_fp16_tiles(vtcm_weight_bufs[0], vtcm_qweight, n_cols_A0, k, weight_row_stride,
-                                                    weight_type);
+        dequantize_x4x2_weight_chunk_to_fp16_tiles(vtcm_weight_bufs[0], vtcm_qweight, n_cols_A0, k, 0, k,
+                                                    weight_row_stride, weight_type);
 
         // A1
         const size_t n_cols_A1 = smin(n - 1 * n_chunk_n_cols, n_chunk_n_cols);
@@ -1319,7 +1333,7 @@ int hmx_mat_mul_af32_pwqk0_of32(float *restrict dst, const float *restrict activ
         // B1: x4x2 tile-based dequantization
         if (1 < n_chunk_cnt) {
           dma_wait_for_idle();
-          dequantize_x4x2_weight_chunk_to_fp16_tiles(vtcm_weight_bufs[1], vtcm_qweight, n_cols_A1, k,
+          dequantize_x4x2_weight_chunk_to_fp16_tiles(vtcm_weight_bufs[1], vtcm_qweight, n_cols_A1, k, 0, k,
                                                       weight_row_stride, weight_type);
         }
       }
@@ -1370,7 +1384,7 @@ int hmx_mat_mul_af32_pwqk0_of32(float *restrict dst, const float *restrict activ
         // wait for DMA (A_{i+2}), compute B_{i+2}
         if (i + 2 < n_chunk_cnt) {
           dma_wait_for_idle();
-          dequantize_x4x2_weight_chunk_to_fp16_tiles(vtcm_weight_bufs[(i + 2) % 2], vtcm_qweight, n_cols_p2, k,
+          dequantize_x4x2_weight_chunk_to_fp16_tiles(vtcm_weight_bufs[(i + 2) % 2], vtcm_qweight, n_cols_p2, k, 0, k,
                                                       weight_row_stride, weight_type);
         }
       }
@@ -1654,7 +1668,7 @@ int mat_mul_af32_pwqk0_of32_stationary(float *restrict out, const float *restric
         // dequantize weight block (x4x2 tile-based with vscatter)
         {
           worker_pool_synctoken_wait(&fetch_task_state.sync_ctx);
-          dequantize_x4x2_weight_chunk_to_fp16_tiles(vtcm_weight, vtcm_scratch0, n_blk_sz, k_blk_sz,
+          dequantize_x4x2_weight_chunk_to_fp16_tiles(vtcm_weight, vtcm_scratch0, n_blk_sz, k_blk_sz, kk, k,
                                                       weight_row_stride, weight_type);
         }
         t_b += HAP_perf_get_qtimer_count() - t1;

--- a/nntrainer/tensor/htp_backend/htp/hmx_ops/mat_mul.c
+++ b/nntrainer/tensor/htp_backend/htp/hmx_ops/mat_mul.c
@@ -710,247 +710,100 @@ void dequantize_common_weight_chunk_qk_0_to_fp16_hvx(__fp16 *vtcm_dst, const voi
 
 // ==================== x4x2 dequantization kernels ====================
 
-// Scatter offsets for writing 2 rows of 32 FP16 values into HMX tile layout.
-// Each element is an offset (in bytes) within the 2KB tile for one FP16 element.
-// 16 valid entries (one per pair of rows), 16 zero-padding entries.
-static const int32_t weight_transpose_scatter_offsets[32] __attribute__((aligned(VLEN))) = {
-  0 * 128, 1 * 128, 2 * 128,  3 * 128,  4 * 128,  5 * 128,  6 * 128,  7 * 128,
-  8 * 128, 9 * 128, 10 * 128, 11 * 128, 12 * 128, 13 * 128, 14 * 128, 15 * 128,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-};
-
-// Dequantize a single Q4_0 group (32 elements) from x4x2 format.
-// packed_quants: pointer to 128-byte packed quants block within the row
-// upper: if true, extract high nibbles; otherwise low nibbles
-// scale_ptr: pointer to the FP16 scale for this group
-// vlut_cvt: LUT vector for INT4->FP16 conversion
-// Returns: HVX vector with 32 dequantized FP16 values (in lower 64 bytes)
-static inline HVX_Vector dequantize_x4x2_q4_0_group_hvx(const uint8_t *packed_quants, bool upper,
-                                                         const __fp16 *scale_ptr, HVX_Vector vlut_cvt) {
-  HVX_Vector vq = vmemu(packed_quants);
-
-  // Extract the relevant nibble (lower or upper 4 bits)
-  HVX_Vector v_nibbles;
-  if (upper) {
-    v_nibbles = Q6_Vub_vlsr_VubR(vq, 4);
-  } else {
-    v_nibbles = vq;  // vlut16 only looks at low 4 bits per byte
-  }
-
-  // LUT conversion: INT4 -> FP16 (32 values)
-  HVX_VectorPair vp_q = Q6_Wh_vlut16_VbVhR_nomatch(v_nibbles, vlut_cvt, 0);
-  HVX_Vector v_quants_hf = Q6_V_lo_W(vp_q);
-
-  // Broadcast scale to all 32 positions
-  HVX_Vector v_scale_raw = vmemu(scale_ptr);
-  HVX_Vector v_scale = Q6_V_lo_W(Q6_Wh_vlut16_VbVhR_nomatch(Q6_V_vzero(), v_scale_raw, 0));
-
-  // Dequantize: quant * scale
-  return Q6_Vhf_equals_Vqf16(Q6_Vqf16_vmpy_VhfVhf(v_quants_hf, v_scale));
-}
-
-// Dequantize 4 consecutive Q4_0 groups from x4x2 format (fast path).
-// packed_quants: pointer to the 128-byte packed quants for these 4 groups
-// upper: if true, extract high nibbles
-// scale_ptr: pointer to 4 consecutive FP16 scales
-// vlut_cvt: LUT for INT4->FP16
-// out[4]: output array of 4 HVX vectors, each with 32 FP16 values
-static inline void dequantize_x4x2_q4_0_x4groups_hvx(const uint8_t *packed_quants, bool upper,
-                                                      const __fp16 *scale_ptr, HVX_Vector vlut_cvt,
-                                                      HVX_Vector out[4]) {
-  HVX_Vector vq = vmemu(packed_quants);
-
-  HVX_Vector v_nibbles;
-  if (upper) {
-    v_nibbles = Q6_Vub_vlsr_VubR(vq, 4);
-  } else {
-    v_nibbles = vq;
-  }
-
-  // Single vlut16 covers all 128 bytes → 4 groups of 32 FP16 values
-  HVX_VectorPair vp_q0 = Q6_Wh_vlut16_VbVhR_nomatch(v_nibbles, vlut_cvt, 0);
-
-  // Load all 4 scales and broadcast
-  HVX_Vector v_packed_scales = vmemu(scale_ptr);
-  HVX_Vector vlut_scales = Q6_V_lo_W(Q6_Wuw_vunpack_Vuh(v_packed_scales));
-
-  // Scale index lookup tables for 4 groups
-  static const uint8_t scale_idx_data_lo[128] __attribute__((aligned(VLEN))) = {
-    0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2,
-    0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2,
-    1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3,
-    1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3,
-  };
-  HVX_Vector vlut_scales_idx0 = vmem(scale_idx_data_lo);
-  HVX_Vector vlut_scales_idx1 = Q6_Vb_vadd_VbVb(vlut_scales_idx0, Q6_Vb_vsplat_R(4));
-
-  HVX_VectorPair vp_s0 = Q6_Wh_vlut16_VbVhR_nomatch(vlut_scales_idx0, vlut_scales, 0);
-  HVX_VectorPair vp_s1 = Q6_Wh_vlut16_VbVhR_nomatch(vlut_scales_idx1, vlut_scales, 0);
-
-  out[0] = Q6_Vhf_equals_Vqf16(Q6_Vqf16_vmpy_VhfVhf(Q6_V_lo_W(vp_q0), Q6_V_lo_W(vp_s0)));
-  out[1] = Q6_Vhf_equals_Vqf16(Q6_Vqf16_vmpy_VhfVhf(Q6_V_hi_W(vp_q0), Q6_V_hi_W(vp_s0)));
-
-  // For groups 2-3, we need the high part of the vlut16 result
-  HVX_VectorPair vp_q1 = Q6_Wh_vlut16_VbVhR_nomatch(Q6_Vub_vlsr_VubR(vq, 4), vlut_cvt, 0);
-  if (!upper) {
-    vp_q1 = Q6_Wh_vlut16_VbVhR_nomatch(v_nibbles, vlut_cvt, 0);
-  }
-
-  out[2] = Q6_Vhf_equals_Vqf16(Q6_Vqf16_vmpy_VhfVhf(Q6_V_lo_W(vp_s1), Q6_V_lo_W(vp_s1)));
-  out[3] = Q6_Vhf_equals_Vqf16(Q6_Vqf16_vmpy_VhfVhf(Q6_V_hi_W(vp_s1), Q6_V_hi_W(vp_s1)));
-
-  // Correct: actually multiply quants by scales
-  out[2] = Q6_Vhf_equals_Vqf16(Q6_Vqf16_vmpy_VhfVhf(Q6_V_lo_W(vp_q1), Q6_V_lo_W(vp_s1)));
-  out[3] = Q6_Vhf_equals_Vqf16(Q6_Vqf16_vmpy_VhfVhf(Q6_V_hi_W(vp_q1), Q6_V_hi_W(vp_s1)));
-}
-
-// Dequantize a single Q8_0 group (32 elements) from x4x2 format.
-static inline HVX_Vector dequantize_x4x2_q8_0_group_hvx(const int8_t *quants, const __fp16 *scale_ptr) {
-  HVX_Vector vq = vmemu(quants);
-
-  // int8 -> FP16: sign-extend to int16, then convert to FP16
-  HVX_Vector v0 = Q6_V_lo_W(Q6_Wh_vunpack_Vb(vq));
-  HVX_Vector v_quants_hf = Q6_Vhf_equals_Vh(v0);
-
-  // Broadcast scale
-  HVX_Vector v_scale_raw = vmemu(scale_ptr);
-  HVX_Vector v_scale = Q6_V_lo_W(Q6_Wh_vlut16_VbVhR_nomatch(Q6_V_vzero(), v_scale_raw, 0));
-
-  return Q6_Vhf_equals_Vqf16(Q6_Vqf16_vmpy_VhfVhf(v_quants_hf, v_scale));
-}
-
-// Main x4x2 tile-based dequantization task.
-// Processes tiles [start_tile, end_tile) and writes dequantized FP16 data
-// directly into HMX tile layout using vscatter.
+// Dequantize x4x2 weight data into HMX FP16 tile layout.
+// Processes tiles [start_tile, end_tile).
+//
+// HMX tile layout: tile element at (k_local, n_local) is stored at
+//   tile[(k_local & ~1) * 32 + n_local * 2 + (k_local & 1)]
+//
+// x4x2 row layout for Q4_0/IQ4_NL:
+//   [packed_quants: K/2 bytes | scale_blocks: (K/256)*16 bytes]
+//   Within packed_quants, each 256-element super-block has 128 bytes:
+//     sub-block 0 (groups 0-3): bytes 0-63, each group 16 bytes
+//     sub-block 1 (groups 4-7): bytes 64-127, each group 16 bytes
+//   Each group's 16 bytes: byte[j] = elem[j] | (elem[j+16] << 4)
+//
+// x4x2 row layout for Q8_0:
+//   [quants: K bytes | scale_blocks: (K/256)*16 bytes]
+//   Each group's 32 bytes: int8 quants[0..31]
 static void dequantize_x4x2_weight_to_fp16_tiles_task(__fp16 *restrict vtcm_dst, const uint8_t *restrict vtcm_src,
                                                       int n_cols, int k_block, size_t row_stride,
                                                       enum ggml_type weight_type, int start_tile, int end_tile) {
   const int n_k_tiles = k_block / HMX_FP16_TILE_N_COLS;
   const int qrow_size = (weight_type == GGML_TYPE_Q8_0) ? k_block : (k_block / 2);
 
-  const HVX_Vector vlut_cvt = (weight_type == GGML_TYPE_IQ4_NL) ? vmem(iq4_nl_to_fp16_lut) : vmem(q4_0_to_fp16_lut);
+  for (int t = start_tile; t < end_tile; ++t) {
+    int ct = t / n_k_tiles;  // N-dimension tile index
+    int kt = t % n_k_tiles;  // K-dimension tile index
 
-  const HVX_Vector v_scat_base = vmem(weight_transpose_scatter_offsets);
-  const HVX_Vector v_scat_step = Q6_V_vsplat_R(4);  // 4 bytes per FP16 pair offset increment
-  const HVX_VectorPred q_mask64 = Q6_Q_vsetq_R(64);  // mask for 32 FP16 elements = 64 bytes
+    __fp16 *tile = vtcm_dst + t * HMX_FP16_TILE_N_ELMS;
 
-  for (int t = start_tile; t < end_tile; ) {
-    int ct = t / n_k_tiles;  // column tile index (N dimension)
-    int kt = t % n_k_tiles;  // k tile index (K dimension)
-
-    // Q4_0/IQ4_NL: 4-tile batch fast path
-    if ((weight_type == GGML_TYPE_Q4_0 || weight_type == GGML_TYPE_IQ4_NL) && (kt % 4 == 0) &&
-        (t + 4 <= end_tile) && ((t + 3) / n_k_tiles == ct)) {
-      int  blk_idx      = (kt * 32) / QK_Q4_0x4x2;
-      int  sub_blk_base = ((kt * 32) % QK_Q4_0x4x2) / 32;
-      bool upper        = (sub_blk_base >= 4);
-      int  packed_off   = blk_idx * (QK_Q4_0x4x2 / 2);
-      int  scale_off    = qrow_size + blk_idx * HMX_X4X2_DBLK_SIZE + sub_blk_base * (int) sizeof(__fp16);
-
-      __fp16 *tile_bases[4];
-      for (int g = 0; g < 4; g++) {
-        tile_bases[g] = vtcm_dst + (t + g) * HMX_FP16_TILE_N_ELMS;
-      }
-
-      HVX_Vector v_off = v_scat_base;
-      for (int r = 0; r < HMX_FP16_TILE_N_ROWS; r += 2) {
-        int row0 = ct * HMX_FP16_TILE_N_COLS + r;
-        int row1 = row0 + 1;
-        const uint8_t *r0 = vtcm_src + row0 * row_stride;
-        const uint8_t *r1 = vtcm_src + row1 * row_stride;
-
-        HVX_Vector v0[4], v1[4];
-        dequantize_x4x2_q4_0_x4groups_hvx(r0 + packed_off, upper, (const __fp16 *) (r0 + scale_off), vlut_cvt, v0);
-        if (row1 < n_cols) {
-          dequantize_x4x2_q4_0_x4groups_hvx(r1 + packed_off, upper, (const __fp16 *) (r1 + scale_off), vlut_cvt, v1);
-        } else {
-          v1[0] = v1[1] = v1[2] = v1[3] = Q6_V_vzero();
-        }
-
-        for (int g = 0; g < 4; g++) {
-          Q6_vscatter_QRMVwV(q_mask64, (size_t) tile_bases[g], HMX_FP16_TILE_SIZE - 1, v_off, v0[g]);
-        }
-        v_off = Q6_Vw_vadd_VwVw(v_off, v_scat_step);
-        for (int g = 0; g < 4; g++) {
-          Q6_vscatter_QRMVwV(q_mask64, (size_t) tile_bases[g], HMX_FP16_TILE_SIZE - 1, v_off, v1[g]);
-        }
-        v_off = Q6_Vw_vadd_VwVw(v_off, v_scat_step);
-      }
-
-      // drain scatter buffer
-      for (int g = 0; g < 4; g++) {
-        (void) *(volatile HVX_Vector *) (tile_bases[g]);
-      }
-
-      t += 4;
-      continue;
-    }
-
-    // Single-tile fallback for Q4_0/IQ4_NL
-    __fp16 *tile_base = vtcm_dst + t * HMX_FP16_TILE_N_ELMS;
+    // Which group within a row does this tile cover?
+    int group_idx  = kt;             // group index (each group = 32 k-elements)
+    int sb_idx     = group_idx / 8;  // super-block index
+    int grp_in_sb  = group_idx % 8;  // group within super-block (0..7)
+    int sub_blk    = grp_in_sb / 4;  // sub-block (0 or 1)
+    int grp_in_sub = grp_in_sb % 4;  // group within sub-block (0..3)
 
     if (weight_type == GGML_TYPE_Q4_0 || weight_type == GGML_TYPE_IQ4_NL) {
-      int  blk_idx  = (kt * 32) / QK_Q4_0x4x2;
-      int  sub_blk  = ((kt * 32) % QK_Q4_0x4x2) / 32;
-      bool upper    = (sub_blk >= 4);
-      int  byte_off = blk_idx * (QK_Q4_0x4x2 / 2) + (upper ? (sub_blk - 4) : sub_blk) * 32;
-      int  scale_off = qrow_size + blk_idx * HMX_X4X2_DBLK_SIZE + sub_blk * (int) sizeof(__fp16);
+      // Byte offset of this group's 16 packed quant bytes within a row
+      int q_off = sb_idx * 128 + sub_blk * 64 + grp_in_sub * 16;
+      // Byte offset of this group's FP16 scale within a row
+      int s_off = qrow_size + sb_idx * HMX_X4X2_DBLK_SIZE + grp_in_sb * (int) sizeof(__fp16);
 
-      HVX_Vector v_off = v_scat_base;
-      for (int r = 0; r < HMX_FP16_TILE_N_ROWS; r += 2) {
-        int row0 = ct * HMX_FP16_TILE_N_COLS + r;
-        int row1 = row0 + 1;
+      for (int n_local = 0; n_local < HMX_FP16_TILE_N_COLS; ++n_local) {
+        int row = ct * HMX_FP16_TILE_N_COLS + n_local;
 
-        const uint8_t *r0 = vtcm_src + row0 * row_stride;
-        const uint8_t *r1 = vtcm_src + row1 * row_stride;
+        if (row >= n_cols) {
+          // Zero-fill remaining tile rows
+          for (int kl = 0; kl < 32; ++kl) {
+            tile[(kl & ~1) * 32 + n_local * 2 + (kl & 1)] = (__fp16) 0;
+          }
+          continue;
+        }
 
-        HVX_Vector v0 =
-          dequantize_x4x2_q4_0_group_hvx(r0 + byte_off, upper, (const __fp16 *) (r0 + scale_off), vlut_cvt);
-        HVX_Vector v1 = (row1 < n_cols)
-                           ? dequantize_x4x2_q4_0_group_hvx(r1 + byte_off, upper, (const __fp16 *) (r1 + scale_off),
-                                                             vlut_cvt)
-                           : Q6_V_vzero();
+        const uint8_t *row_data = vtcm_src + row * row_stride;
+        const uint8_t *qs       = row_data + q_off;
+        __fp16         scale    = *((const __fp16 *) (row_data + s_off));
+        float          scale_f  = (float) scale;
 
-        Q6_vscatter_QRMVwV(q_mask64, (size_t) tile_base, HMX_FP16_TILE_SIZE - 1, v_off, v0);
-        v_off = Q6_Vw_vadd_VwVw(v_off, v_scat_step);
-        Q6_vscatter_QRMVwV(q_mask64, (size_t) tile_base, HMX_FP16_TILE_SIZE - 1, v_off, v1);
-        v_off = Q6_Vw_vadd_VwVw(v_off, v_scat_step);
+        for (int j = 0; j < 16; ++j) {
+          int q_lo = qs[j] & 0x0F;
+          int q_hi = (qs[j] >> 4) & 0x0F;
+
+          __fp16 v_lo = (__fp16) ((float) (q_lo - 8) * scale_f);
+          __fp16 v_hi = (__fp16) ((float) (q_hi - 8) * scale_f);
+
+          // k_local = j for lo nibble (elements 0..15), j+16 for hi nibble (elements 16..31)
+          tile[(j & ~1) * 32 + n_local * 2 + (j & 1)]             = v_lo;
+          tile[((j + 16) & ~1) * 32 + n_local * 2 + ((j + 16) & 1)] = v_hi;
+        }
       }
-      (void) *(volatile HVX_Vector *) (tile_base);
     } else if (weight_type == GGML_TYPE_Q8_0) {
-      int blk_idx   = (kt * 32) / QK_Q8_0x4x2;
-      int sub_blk   = ((kt * 32) % QK_Q8_0x4x2) / 32;
-      int byte_off  = blk_idx * QK_Q8_0x4x2 + sub_blk * 32;
-      int scale_off = qrow_size + blk_idx * HMX_X4X2_DBLK_SIZE + sub_blk * (int) sizeof(__fp16);
+      int q_off = sb_idx * QK_Q8_0x4x2 + grp_in_sb * 32;
+      int s_off = qrow_size + sb_idx * HMX_X4X2_DBLK_SIZE + grp_in_sb * (int) sizeof(__fp16);
 
-      HVX_Vector v_off = v_scat_base;
-      for (int r = 0; r < HMX_FP16_TILE_N_ROWS; r += 2) {
-        int row0 = ct * HMX_FP16_TILE_N_COLS + r;
-        int row1 = row0 + 1;
+      for (int n_local = 0; n_local < HMX_FP16_TILE_N_COLS; ++n_local) {
+        int row = ct * HMX_FP16_TILE_N_COLS + n_local;
 
-        const uint8_t *r0 = vtcm_src + row0 * row_stride;
-        const uint8_t *r1 = vtcm_src + row1 * row_stride;
+        if (row >= n_cols) {
+          for (int kl = 0; kl < 32; ++kl) {
+            tile[(kl & ~1) * 32 + n_local * 2 + (kl & 1)] = (__fp16) 0;
+          }
+          continue;
+        }
 
-        HVX_Vector v0 = dequantize_x4x2_q8_0_group_hvx((const int8_t *) (r0 + byte_off),
-                                                         (const __fp16 *) (r0 + scale_off));
-        HVX_Vector v1 =
-          (row1 < n_cols)
-            ? dequantize_x4x2_q8_0_group_hvx((const int8_t *) (r1 + byte_off), (const __fp16 *) (r1 + scale_off))
-            : Q6_V_vzero();
+        const uint8_t *row_data = vtcm_src + row * row_stride;
+        const int8_t  *qs       = (const int8_t *) (row_data + q_off);
+        __fp16         scale    = *((const __fp16 *) (row_data + s_off));
+        float          scale_f  = (float) scale;
 
-        Q6_vscatter_QRMVwV(q_mask64, (size_t) tile_base, HMX_FP16_TILE_SIZE - 1, v_off, v0);
-        v_off = Q6_Vw_vadd_VwVw(v_off, v_scat_step);
-        Q6_vscatter_QRMVwV(q_mask64, (size_t) tile_base, HMX_FP16_TILE_SIZE - 1, v_off, v1);
-        v_off = Q6_Vw_vadd_VwVw(v_off, v_scat_step);
+        for (int kl = 0; kl < 32; ++kl) {
+          __fp16 v = (__fp16) ((float) qs[kl] * scale_f);
+          tile[(kl & ~1) * 32 + n_local * 2 + (kl & 1)] = v;
+        }
       }
-      (void) *(volatile HVX_Vector *) (tile_base);
     }
-    ++t;
-  }
-
-  // final drain
-  if (start_tile < end_tile) {
-    (void) *(volatile HVX_Vector *) (vtcm_dst + (end_tile - 1) * HMX_FP16_TILE_N_ELMS);
   }
 }
 

--- a/nntrainer/tensor/htp_backend/htp/hmx_ops/mat_mul.c
+++ b/nntrainer/tensor/htp_backend/htp/hmx_ops/mat_mul.c
@@ -1004,13 +1004,13 @@ void dequantize_x4x2_weight_chunk_to_fp16_tiles(__fp16 *vtcm_dst, const void *vt
 
   int n_col_tiles = n_cols / HMX_FP16_TILE_N_COLS;
   int n_k_tiles   = k_block / HMX_FP16_TILE_N_COLS;
-  int n_tot_tiles = n_col_tiles * n_k_tiles;
+  int n_tot_chunks = n_col_tiles * n_k_tiles;
 
   int    n_workers         = num_hvx128_contexts;
-  size_t n_tiles_per_task  = ceil_div(n_tot_tiles, n_workers);
+  size_t n_chunks_per_task = ceil_div(n_tot_chunks, n_workers);
 
   x4x2_dequantize_task_state_t state;
-  INIT_COMMON_TASK_STATE_MEMBERS(state, n_tot_tiles, n_tiles_per_task);
+  INIT_COMMON_TASK_STATE_MEMBERS(state, n_tot_chunks, n_chunks_per_task);
   state.dst         = vtcm_dst;
   state.src         = (const uint8_t *) vtcm_src;
   state.n_cols      = n_cols;

--- a/nntrainer/tensor/htp_backend/htp/op_executor.cc
+++ b/nntrainer/tensor/htp_backend/htp/op_executor.cc
@@ -14,19 +14,6 @@
 
 namespace {
 
-size_t ggml_super_block_size(enum ggml_type type) {
-  // TODO: more types
-  switch (type) {
-    case GGML_TYPE_Q4_0:
-    case GGML_TYPE_IQ4_NL:
-      return sizeof(my_block_q4_0);
-    case GGML_TYPE_Q8_0:
-      return sizeof(my_block_q8_0);
-    default:
-      return -1;
-  }
-}
-
 enum ggml_type matmul_op_to_weight_type(enum HtpOpsIndex op) {
   switch (op) {
     case HTP_OPS_MAT_MUL_PERMUTED_W16A32:

--- a/nntrainer/tensor/htp_backend/htp/op_executor.cc
+++ b/nntrainer/tensor/htp_backend/htp/op_executor.cc
@@ -116,14 +116,14 @@ int execute_op_simple(struct OpComputeRequest *req) {
     case HTP_OPS_MAT_MUL_PERMUTED_W4D16A32_IQ4_NL:
       {
         auto   weight_type      = matmul_op_to_weight_type(static_cast<HtpOpsIndex>(req->op));
-        size_t super_block_size = ggml_super_block_size(weight_type);
 
         auto params = reinterpret_cast<MatMulParams *>(req->payload);
         int  m = params->m, k = params->k, n = params->n;
 
-        size_t output_size     = m * n * sizeof(float);
-        size_t activation_size = m * k * sizeof(float);
-        size_t weight_size     = k * n / QK_K * super_block_size;
+        size_t weight_row_stride = compute_x4x2_row_stride(k, weight_type);
+        size_t output_size       = m * n * sizeof(float);
+        size_t activation_size   = m * k * sizeof(float);
+        size_t weight_size       = (size_t)n * weight_row_stride;
 
         add_buffer(out_bufs, params->output, output_size);
         add_buffer(in_bufs, params->activation, activation_size);
@@ -132,8 +132,8 @@ int execute_op_simple(struct OpComputeRequest *req) {
         // int64_t t0 = HAP_perf_get_qtimer_count();
         validate_in_bufs();
         // int64_t t1 = HAP_perf_get_qtimer_count();
-        ret =
-          hmx_mat_mul_af32_pwqk0_of32((float *) OUT_PTR(0), (float *) IN_PTR(0), IN_PTR(1), m, k, n, weight_type);
+        ret = hmx_mat_mul_af32_pwqk0_of32((float *) OUT_PTR(0), (float *) IN_PTR(0), IN_PTR(1), m, k, n,
+                                           weight_row_stride, weight_type);
         // int64_t t2 = HAP_perf_get_qtimer_count();
         validate_out_bufs();
         // int64_t t3 = HAP_perf_get_qtimer_count();

--- a/nntrainer/tensor/htp_backend/include/htp/ops.h
+++ b/nntrainer/tensor/htp_backend/include/htp/ops.h
@@ -15,7 +15,7 @@ extern "C" {
 // Matrix Multiplication Operations
 int hmx_mat_mul_af32_pwf16_of32(float *restrict out, const float *act, const __fp16 *p_wgt, int m, int k, int n);
 int hmx_mat_mul_af32_wf16_of32(float *restrict out, const float *restrict act, const __fp16 *restrict wgt, int m, int k, int n);
-int hmx_mat_mul_af32_pwqk0_of32(float *restrict dst, const float *activation, const uint8_t *permuted_weight, int m, int k, int n, enum ggml_type weight_type);
+int hmx_mat_mul_af32_pwqk0_of32(float *restrict dst, const float *activation, const uint8_t *permuted_weight, int m, int k, int n, size_t weight_row_stride, enum ggml_type weight_type);
 
 int hvx_rms_norm_f32(float *restrict dst, const float *restrict src, int ne0, int ne1);
 

--- a/nntrainer/tensor/htp_backend/include/htp/quants.h
+++ b/nntrainer/tensor/htp_backend/include/htp/quants.h
@@ -30,6 +30,24 @@ typedef struct {
   int8_t quants[8 * QK8_0];
 } __attribute__((packed)) my_block_q8_0;
 
+// x4x2 format constants: 4 groups x 2 sub-blocks (lo/hi nibbles)
+// Row layout: [packed_quants | scale_blocks]
+#define QK_Q4_0x4x2          256  // 4 groups × 2 sub-blocks × 32 elements
+#define QK_Q8_0x4x2          256
+#define HMX_X4X2_SCALES_PER_BLK  8
+#define HMX_X4X2_DBLK_SIZE       16  // 8 × sizeof(__fp16) = 16 bytes per scale block
+
+// Compute the row stride for x4x2 weight format (bytes per weight row of K elements)
+// Q4_0/IQ4_NL: quants = K/2 bytes, scales = (K/QK_Q4_0x4x2) * HMX_X4X2_DBLK_SIZE bytes
+// Q8_0:        quants = K bytes,   scales = (K/QK_Q8_0x4x2) * HMX_X4X2_DBLK_SIZE bytes
+static inline size_t compute_x4x2_row_stride_q4_0(int k) {
+  return (size_t)(k / 2) + (size_t)(k / QK_Q4_0x4x2) * HMX_X4X2_DBLK_SIZE;
+}
+
+static inline size_t compute_x4x2_row_stride_q8_0(int k) {
+  return (size_t)k + (size_t)(k / QK_Q8_0x4x2) * HMX_X4X2_DBLK_SIZE;
+}
+
 enum ggml_type {
   GGML_TYPE_F32     = 0,
   GGML_TYPE_F16     = 1,
@@ -72,3 +90,16 @@ enum ggml_type {
   // GGML_TYPE_IQ4_NL_8_8 = 38,
   GGML_TYPE_COUNT   = 39,
 };
+
+// Unified helper to compute x4x2 row stride by weight type
+static inline size_t compute_x4x2_row_stride(int k, enum ggml_type weight_type) {
+  switch (weight_type) {
+    case GGML_TYPE_Q4_0:
+    case GGML_TYPE_IQ4_NL:
+      return compute_x4x2_row_stride_q4_0(k);
+    case GGML_TYPE_Q8_0:
+      return compute_x4x2_row_stride_q8_0(k);
+    default:
+      return 0;
+  }
+}

--- a/nntrainer/tensor/htp_backend/include/htp/quants.h
+++ b/nntrainer/tensor/htp_backend/include/htp/quants.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 
 #define QK_K 256  // super-block size

--- a/nntrainer/tensor/q4_0_utils.cpp
+++ b/nntrainer/tensor/q4_0_utils.cpp
@@ -302,6 +302,66 @@ void Q4_0Utils::repackToX4x2_Q4_0(const block_q4_0 *src_q4_0,
   }
 }
 
+void Q4_0Utils::repackToX4x2_Q4_0x8(const block_q4_0x8 *src_x8,
+                                     uint8_t *dst_x4x2, size_t N, size_t K,
+                                     size_t *out_row_stride) {
+  assert(K % 256 == 0);
+  assert(N % 8 == 0);
+
+  const size_t nblocks = K / QK4_0; // blocks per row
+  const size_t quants_per_row = K / 2;
+  const size_t n_superblocks_per_row = K / 256;
+  const size_t scales_per_row = n_superblocks_per_row * 16;
+  const size_t row_stride = quants_per_row + scales_per_row;
+
+  *out_row_stride = row_stride;
+
+  const uint64_t xor_mask = 0x8888888888888888ULL;
+
+  // block_q4_0x8 data is stored as groups of 8 rows.
+  // Within each group, blocks are stored sequentially:
+  //   group0: [blk_x8(row0-7, col_blk0), blk_x8(row0-7, col_blk1), ...]
+  //   group1: [blk_x8(row8-15, col_blk0), ...]
+  const block_q4_0x8 *src = src_x8;
+
+  for (size_t row_base = 0; row_base < N; row_base += 8) {
+    for (size_t x = 0; x < nblocks; ++x) {
+      const block_q4_0x8 *blk = src++;
+
+      // Unpack this block_q4_0x8 into 8 rows' x4x2 data
+      // block_q4_0x8 layout (with XOR applied by quantizer):
+      //   d[8]: scales for 8 rows
+      //   qs[0..63]:   first 8 bytes of each row's block (rows 0-7), XORed
+      //   qs[64..127]: second 8 bytes of each row's block (rows 0-7), XORed
+
+      size_t sb_idx = x / 8;
+      size_t grp_in_sb = x % 8;
+      size_t sub_blk = grp_in_sb / 4;
+      size_t grp_in_sub = grp_in_sb % 4;
+      size_t q_off = sb_idx * 128 + sub_blk * 64 + grp_in_sub * 16;
+      size_t s_off = quants_per_row + sb_idx * 16 + grp_in_sb * 2;
+
+      for (int r = 0; r < 8; ++r) {
+        size_t row = row_base + r;
+        if (row >= N) break;
+        uint8_t *dst_row = dst_x4x2 + row * row_stride;
+
+        // Reverse XOR and copy 16 quant bytes (two 8-byte halves)
+        uint64_t lo, hi;
+        std::memcpy(&lo, &blk->qs[r * 8], sizeof(uint64_t));
+        std::memcpy(&hi, &blk->qs[64 + r * 8], sizeof(uint64_t));
+        lo ^= xor_mask;
+        hi ^= xor_mask;
+        std::memcpy(dst_row + q_off, &lo, sizeof(uint64_t));
+        std::memcpy(dst_row + q_off + 8, &hi, sizeof(uint64_t));
+
+        // Copy scale (FP16)
+        std::memcpy(dst_row + s_off, &blk->d[r], sizeof(uint16_t));
+      }
+    }
+  }
+}
+
 void Q4_0Utils::repackToX4x2_Q8_0(const int8_t *src_q8_0,
                                     const uint16_t *scales,
                                     uint8_t *dst_x4x2, size_t N, size_t K,

--- a/nntrainer/tensor/q4_0_utils.cpp
+++ b/nntrainer/tensor/q4_0_utils.cpp
@@ -10,6 +10,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <cstring>
 
 #include "cpu_backend.h"
 #include "fp16.h"
@@ -246,6 +247,93 @@ void Q4_0Utils::printBlockQ4_0(const block_q4_0 *block) {
     printf("%i %i ", block->qs[i] & 0x0F, (block->qs[i] >> 4) & 0x0F);
   }
   printf("| scale:%f\n", compute_fp16_to_fp32(block->d));
+}
+
+void Q4_0Utils::repackToX4x2_Q4_0(const block_q4_0 *src_q4_0,
+                                   uint8_t *dst_x4x2, size_t N, size_t K,
+                                   size_t *out_row_stride) {
+  // x4x2 format: each row (one output neuron) stores K elements as:
+  //   [packed_quants: K/2 bytes] [scale_blocks: (K/256) * 16 bytes]
+  // Within packed_quants: 4 groups of 32 elements interleaved as x4x2 blocks
+  //   Each 256-element super-block has 128 bytes of packed 4-bit values
+  //   arranged as 4 groups x 2 sub-blocks (lo/hi nibbles)
+  // Scale blocks: 8 FP16 scales per 256-element block
+
+  assert(K % 256 == 0);
+  const size_t n_groups_per_row = K / QK4_0;  // groups of 32 elements per row
+  const size_t quants_per_row = K / 2;         // bytes of packed 4-bit quants
+  const size_t n_superblocks_per_row = K / 256;
+  const size_t scales_per_row = n_superblocks_per_row * 16;  // 16 bytes per scale block
+  const size_t row_stride = quants_per_row + scales_per_row;
+
+  *out_row_stride = row_stride;
+
+  for (size_t row = 0; row < N; ++row) {
+    uint8_t *dst_row = dst_x4x2 + row * row_stride;
+    uint8_t *dst_quants = dst_row;
+    uint8_t *dst_scales = dst_row + quants_per_row;
+
+    // Source: each row has n_groups_per_row block_q4_0 blocks
+    const block_q4_0 *src_row = src_q4_0 + row * n_groups_per_row;
+
+    // Pack quants: interleave 4 groups into x4x2 sub-blocks (128 bytes per 256 elements)
+    for (size_t sb = 0; sb < n_superblocks_per_row; ++sb) {
+      // Each super-block has 8 groups of 32 elements
+      // x4x2 layout: groups 0-3 share lo nibbles, groups 4-7 share hi nibbles
+      // Pack all 8 groups' quants into 128 bytes
+      uint8_t *sb_quants = dst_quants + sb * 128;
+      uint16_t *sb_scales = (uint16_t *)(dst_scales + sb * 16);
+
+      for (int g = 0; g < 8; ++g) {
+        const block_q4_0 *group = &src_row[sb * 8 + g];
+
+        // Copy 16 bytes of packed quants for this group
+        // In x4x2, groups 0-3 go to sub-block 0, groups 4-7 to sub-block 1
+        // Each sub-block has 4 groups x 16 bytes = 64 bytes
+        int sub_blk = g / 4;
+        int sub_idx = g % 4;
+        std::memcpy(sb_quants + sub_blk * 64 + sub_idx * 16, group->qs,
+                    QK4_0 / 2);
+
+        // Copy scale (FP16, stored as uint16_t)
+        sb_scales[g] = group->d;
+      }
+    }
+  }
+}
+
+void Q4_0Utils::repackToX4x2_Q8_0(const int8_t *src_q8_0,
+                                    const uint16_t *scales,
+                                    uint8_t *dst_x4x2, size_t N, size_t K,
+                                    size_t *out_row_stride) {
+  assert(K % 256 == 0);
+  const size_t n_groups_per_row = K / 32;
+  const size_t quants_per_row = K;  // 1 byte per element for Q8_0
+  const size_t n_superblocks_per_row = K / 256;
+  const size_t scales_per_row = n_superblocks_per_row * 16;
+  const size_t row_stride = quants_per_row + scales_per_row;
+
+  *out_row_stride = row_stride;
+
+  for (size_t row = 0; row < N; ++row) {
+    uint8_t *dst_row = dst_x4x2 + row * row_stride;
+    int8_t *dst_quants = (int8_t *)dst_row;
+    uint8_t *dst_scales_region = dst_row + quants_per_row;
+
+    const int8_t *src_row_quants = src_q8_0 + row * K;
+    const uint16_t *src_row_scales = scales + row * n_groups_per_row;
+
+    // Copy quants directly (Q8_0 quants are stored as-is in x4x2)
+    std::memcpy(dst_quants, src_row_quants, K);
+
+    // Pack scales into x4x2 scale blocks (8 scales per 256-element block)
+    for (size_t sb = 0; sb < n_superblocks_per_row; ++sb) {
+      uint16_t *sb_scales = (uint16_t *)(dst_scales_region + sb * 16);
+      for (int g = 0; g < 8; ++g) {
+        sb_scales[g] = src_row_scales[sb * 8 + g];
+      }
+    }
+  }
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/q4_0_utils.cpp
+++ b/nntrainer/tensor/q4_0_utils.cpp
@@ -302,6 +302,62 @@ void Q4_0Utils::repackToX4x2_Q4_0(const block_q4_0 *src_q4_0,
   }
 }
 
+void Q4_0Utils::repackToX4x2_Q4_0x4(const block_q4_0x4 *src_x4,
+                                     uint8_t *dst_x4x2, size_t N, size_t K,
+                                     size_t *out_row_stride) {
+  assert(K % 256 == 0);
+  assert(N % 4 == 0);
+
+  const size_t nblocks = K / QK4_0;
+  const size_t quants_per_row = K / 2;
+  const size_t n_superblocks_per_row = K / 256;
+  const size_t scales_per_row = n_superblocks_per_row * 16;
+  const size_t row_stride = quants_per_row + scales_per_row;
+
+  *out_row_stride = row_stride;
+
+  const uint64_t xor_mask = 0x8888888888888888ULL;
+
+  // block_q4_0x4 data: groups of 4 rows, blocks sequential within each group.
+  const block_q4_0x4 *src = src_x4;
+
+  for (size_t row_base = 0; row_base < N; row_base += 4) {
+    for (size_t x = 0; x < nblocks; ++x) {
+      const block_q4_0x4 *blk = src++;
+
+      // block_q4_0x4 layout (with XOR, blck_size_interleave=8):
+      //   d[4]: scales for 4 rows
+      //   qs[r*8 .. r*8+7]:    first 8 bytes of row r's block quants, XORed
+      //   qs[32+r*8 .. 32+r*8+7]: second 8 bytes of row r's block quants, XORed
+
+      size_t sb_idx = x / 8;
+      size_t grp_in_sb = x % 8;
+      size_t sub_blk = grp_in_sb / 4;
+      size_t grp_in_sub = grp_in_sb % 4;
+      size_t q_off = sb_idx * 128 + sub_blk * 64 + grp_in_sub * 16;
+      size_t s_off = quants_per_row + sb_idx * 16 + grp_in_sb * 2;
+
+      for (int r = 0; r < 4; ++r) {
+        size_t row = row_base + r;
+        if (row >= N) break;
+        uint8_t *dst_row = dst_x4x2 + row * row_stride;
+
+        // Reverse XOR and copy 16 quant bytes (two 8-byte halves)
+        uint64_t lo, hi;
+        std::memcpy(&lo, &blk->qs[r * 8], sizeof(uint64_t));
+        std::memcpy(&hi, &blk->qs[32 + r * 8], sizeof(uint64_t));
+        lo ^= xor_mask;
+        hi ^= xor_mask;
+        std::memcpy(dst_row + q_off, &lo, sizeof(uint64_t));
+        std::memcpy(dst_row + q_off + 8, &hi, sizeof(uint64_t));
+
+        // Copy scale (FP16)
+        std::memcpy(dst_row + s_off, &blk->d[r], sizeof(uint16_t));
+      }
+    }
+  }
+}
+
 void Q4_0Utils::repackToX4x2_Q4_0x8(const block_q4_0x8 *src_x8,
                                      uint8_t *dst_x4x2, size_t N, size_t K,
                                      size_t *out_row_stride) {

--- a/nntrainer/tensor/q4_0_utils.h
+++ b/nntrainer/tensor/q4_0_utils.h
@@ -152,6 +152,21 @@ public:
                                  size_t N, size_t K, size_t *out_row_stride);
 
   /**
+   * @brief Repack Q4_0 weights from block_q4_0x8 interleaved format to x4x2
+   * row-strided format. This directly converts from the block_q4_0x8 format
+   * (used by the model quantizer with XOR mask) to x4x2 format (used by DSP),
+   * reversing the XOR mask in the process.
+   * @param[in] src_x8 source data in block_q4_0x8 format
+   * @param[in] N number of output rows (must be divisible by 8)
+   * @param[in] K number of input columns (must be divisible by 256)
+   * @param[out] dst_x4x2 output buffer in x4x2 row-strided format
+   * @param[out] out_row_stride bytes per row in the output
+   */
+  static void repackToX4x2_Q4_0x8(const block_q4_0x8 *src_x8,
+                                   uint8_t *dst_x4x2, size_t N, size_t K,
+                                   size_t *out_row_stride);
+
+  /**
    * @brief Repack Q8_0 weights from block_q8_0-like format to x4x2
    * row-strided format. Similar to Q4_0 but quants are 8-bit.
    * @param[in] src_q8_0 source data in int8 quantized format

--- a/nntrainer/tensor/q4_0_utils.h
+++ b/nntrainer/tensor/q4_0_utils.h
@@ -152,10 +152,23 @@ public:
                                  size_t N, size_t K, size_t *out_row_stride);
 
   /**
+   * @brief Repack Q4_0 weights from block_q4_0x4 interleaved format to x4x2
+   * row-strided format. On ARM, the quantizer packs Q4_0 data into block_q4_0x4
+   * (4 rows interleaved with XOR mask). This directly converts to x4x2.
+   * @param[in] src_x4 source data in block_q4_0x4 format
+   * @param[in] N number of output rows (must be divisible by 4)
+   * @param[in] K number of input columns (must be divisible by 256)
+   * @param[out] dst_x4x2 output buffer in x4x2 row-strided format
+   * @param[out] out_row_stride bytes per row in the output
+   */
+  static void repackToX4x2_Q4_0x4(const block_q4_0x4 *src_x4,
+                                   uint8_t *dst_x4x2, size_t N, size_t K,
+                                   size_t *out_row_stride);
+
+  /**
    * @brief Repack Q4_0 weights from block_q4_0x8 interleaved format to x4x2
-   * row-strided format. This directly converts from the block_q4_0x8 format
-   * (used by the model quantizer with XOR mask) to x4x2 format (used by DSP),
-   * reversing the XOR mask in the process.
+   * row-strided format. On x86, the quantizer packs Q4_0 data into block_q4_0x8
+   * (8 rows interleaved with XOR mask). This directly converts to x4x2.
    * @param[in] src_x8 source data in block_q4_0x8 format
    * @param[in] N number of output rows (must be divisible by 8)
    * @param[in] K number of input columns (must be divisible by 256)

--- a/nntrainer/tensor/q4_0_utils.h
+++ b/nntrainer/tensor/q4_0_utils.h
@@ -136,6 +136,34 @@ public:
    * @param[in] block Pointer to the Q4_0 block
    */
   static void printBlockQ4_0(const block_q4_0 *block);
+
+  /**
+   * @brief Repack Q4_0 weights from block_q4_0 format to x4x2 row-strided
+   * format. x4x2 row layout: [packed_quants (K/2 bytes) | scale_blocks]
+   * Each row represents one output neuron (N dimension). Scales are grouped
+   * in blocks of 8 FP16 values (HMX_X4X2_DBLK_SIZE = 16 bytes).
+   * @param[in] src_q4_0 source data in block_q4_0 format (N * K/32 blocks)
+   * @param[in] N number of output rows
+   * @param[in] K number of input columns (must be divisible by 256)
+   * @param[out] dst_x4x2 output buffer in x4x2 row-strided format
+   * @param[out] out_row_stride bytes per row in the output
+   */
+  static void repackToX4x2_Q4_0(const block_q4_0 *src_q4_0, uint8_t *dst_x4x2,
+                                 size_t N, size_t K, size_t *out_row_stride);
+
+  /**
+   * @brief Repack Q8_0 weights from block_q8_0-like format to x4x2
+   * row-strided format. Similar to Q4_0 but quants are 8-bit.
+   * @param[in] src_q8_0 source data in int8 quantized format
+   * @param[in] scales source FP16 scales
+   * @param[in] N number of output rows
+   * @param[in] K number of input columns (must be divisible by 256)
+   * @param[out] dst_x4x2 output buffer
+   * @param[out] out_row_stride bytes per row
+   */
+  static void repackToX4x2_Q8_0(const int8_t *src_q8_0,
+                                 const uint16_t *scales, uint8_t *dst_x4x2,
+                                 size_t N, size_t K, size_t *out_row_stride);
 };
 } // namespace nntrainer
 

--- a/test/unittest/unittest_htp_kernels.cpp
+++ b/test/unittest/unittest_htp_kernels.cpp
@@ -555,25 +555,25 @@ DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(28, 512, 256);
 DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(128, 4096, 2048);
 
 /**
- * @brief Simulate the quantizer's packing: block_q4_0 → block_q4_0x8 (with XOR)
+ * @brief Simulate the ARM quantizer's packing: block_q4_0 → block_q4_0x4
+ * (with XOR, blck_size_interleave=8, matching nntr_make_block_q4_0x4 in NEON)
  */
-static void pack_q4_0_to_q4_0x8(const block_q4_0 *src, block_q4_0x8 *dst,
+static void pack_q4_0_to_q4_0x4(const block_q4_0 *src, block_q4_0x4 *dst,
                                  int N, int K) {
   const int nblocks = K / QK4_0;
   const uint64_t xor_mask = 0x8888888888888888ULL;
 
-  for (int b = 0; b < N; b += 8) {
+  for (int b = 0; b < N; b += 4) {
     for (int x = 0; x < nblocks; ++x) {
-      // Gather 8 rows' block x
-      block_q4_0 tmp[8];
-      for (int i = 0; i < 8; ++i) {
+      block_q4_0 tmp[4];
+      for (int i = 0; i < 4; ++i)
         tmp[i] = src[(b + i) * nblocks + x];
-      }
-      // Pack with XOR mask (same as nntr_make_block_q4_0x8 in ggml_impl)
-      for (int i = 0; i < 8; ++i) dst->d[i] = tmp[i].d;
-      for (int i = 0; i < 16; ++i) {
-        int src_id = i % 8;
-        int src_off = (i / 8) * 8;
+
+      for (int i = 0; i < 4; ++i) dst->d[i] = tmp[i].d;
+      // blck_size_interleave=8: end = 32 * 2 / 8 = 8
+      for (int i = 0; i < 8; ++i) {
+        int src_id = i % 4;
+        int src_off = (i / 4) * 8;
         int dst_off = i * 8;
         uint64_t elems;
         memcpy(&elems, &tmp[src_id].qs[src_off], sizeof(uint64_t));
@@ -586,10 +586,11 @@ static void pack_q4_0_to_q4_0x8(const block_q4_0 *src, block_q4_0x8 *dst,
 }
 
 /**
- * @brief Test that repackToX4x2_Q4_0x8 (block_q4_0x8 → x4x2) produces the
+ * @brief Test that repackToX4x2_Q4_0x4 (block_q4_0x4 → x4x2) produces the
  * same DSP results as the original path (block_q4_0 → x4x2).
+ * This tests the ARM model-inference path.
  */
-static void run_repack_q4_0x8_to_x4x2_test(const uint32_t M,
+static void run_repack_q4_0x4_to_x4x2_test(const uint32_t M,
                                              const uint32_t K,
                                              const uint32_t N) {
   auto &htp = htp::HtpInterface::instance();
@@ -612,9 +613,9 @@ static void run_repack_q4_0x8_to_x4x2_test(const uint32_t M,
     quantize_row_q4_0_ref(weight_f32.data() + row * K,
                           weight_q4.data() + row * nblocks, K);
 
-  // Pack to block_q4_0x8 (simulates quantizer)
-  std::vector<block_q4_0x8> weight_x8((N / 8) * nblocks);
-  pack_q4_0_to_q4_0x8(weight_q4.data(), weight_x8.data(), N, K);
+  // Pack to block_q4_0x4 (simulates ARM quantizer)
+  std::vector<block_q4_0x4> weight_x4((N / 4) * nblocks);
+  pack_q4_0_to_q4_0x4(weight_q4.data(), weight_x4.data(), N, K);
 
   // Path A: block_q4_0 → x4x2 (direct, known-good)
   size_t row_stride = (size_t)(K / 2) + (size_t)(K / 256) * 16;
@@ -622,16 +623,16 @@ static void run_repack_q4_0x8_to_x4x2_test(const uint32_t M,
   std::vector<uint8_t> x4x2_A(wt_size, 0);
   repack_q4_0_to_x4x2(weight_q4.data(), x4x2_A.data(), N, K);
 
-  // Path B: block_q4_0x8 → x4x2 (new direct function)
+  // Path B: block_q4_0x4 → x4x2 (new direct function)
   std::vector<uint8_t> x4x2_B(wt_size, 0);
   size_t actual_stride = 0;
-  nntrainer::Q4_0Utils::repackToX4x2_Q4_0x8(weight_x8.data(), x4x2_B.data(),
+  nntrainer::Q4_0Utils::repackToX4x2_Q4_0x4(weight_x4.data(), x4x2_B.data(),
                                               N, K, &actual_stride);
   ASSERT_EQ(actual_stride, row_stride);
 
   // Compare the two x4x2 outputs byte-for-byte
   EXPECT_EQ(x4x2_A, x4x2_B)
-    << "repackToX4x2_Q4_0x8 output differs from repackToX4x2_Q4_0 output";
+    << "repackToX4x2_Q4_0x4 output differs from repackToX4x2_Q4_0 output";
 
   // Also verify DSP produces correct results via path B
   std::vector<float> weight_deq(N * K);
@@ -670,7 +671,7 @@ static void run_repack_q4_0x8_to_x4x2_test(const uint32_t M,
   memcpy(hmx_dst.data(), output_ptr, M * N * sizeof(float));
 
   float mse_err = mse<float>(hmx_dst.data(), ref_dst.data(), M * N);
-  std::cout << "Q4_0x8→x4x2 GEMM: " << M << "x" << K << "x" << N
+  std::cout << "Q4_0x4→x4x2 GEMM: " << M << "x" << K << "x" << N
             << "  MSE=" << mse_err << std::endl;
   EXPECT_IN_RANGE(mse_err, 0.0f, 0.05f);
 
@@ -679,15 +680,15 @@ static void run_repack_q4_0x8_to_x4x2_test(const uint32_t M,
   htp.free_shared_mem_buf(wt_ptr, wt_fd, wt_size);
 }
 
-#define DECLARE_repack_q4_0x8_test(M, K, N)                                    \
-  TEST(nntrainer_htp_kernels, repack_q4_0x8_to_x4x2_##M##_##K##_##N) {        \
-    run_repack_q4_0x8_to_x4x2_test(M, K, N);                                  \
+#define DECLARE_repack_q4_0x4_test(M, K, N)                                    \
+  TEST(nntrainer_htp_kernels, repack_q4_0x4_to_x4x2_##M##_##K##_##N) {        \
+    run_repack_q4_0x4_to_x4x2_test(M, K, N);                                  \
   }
 
-DECLARE_repack_q4_0x8_test(32, 256, 256);
-DECLARE_repack_q4_0x8_test(1, 512, 512);
-DECLARE_repack_q4_0x8_test(32, 1024, 256);
-DECLARE_repack_q4_0x8_test(128, 4096, 2048);
+DECLARE_repack_q4_0x4_test(32, 256, 256);
+DECLARE_repack_q4_0x4_test(1, 512, 512);
+DECLARE_repack_q4_0x4_test(32, 1024, 256);
+DECLARE_repack_q4_0x4_test(128, 4096, 2048);
 
 #else
 

--- a/test/unittest/unittest_htp_kernels.cpp
+++ b/test/unittest/unittest_htp_kernels.cpp
@@ -310,6 +310,249 @@ DECLARE_mat_mul_af32_wf16_of32_test_M_K_N(68, 256, 256);
 DECLARE_mat_mul_af32_wf16_of32_test_M_K_N(28, 512, 256);
 DECLARE_mat_mul_af32_wf16_of32_test_M_K_N(68, 256, 512);
 
+/**
+ * @brief Quantize a row of K floats into K/32 block_q4_0 blocks.
+ *
+ * Each block covers 32 elements: find absmax, compute scale = absmax/8,
+ * then quantize each element to 4-bit unsigned int (0..15) with zero-point 8.
+ * Two consecutive quants are packed into one byte (low nibble first).
+ */
+static void quantize_row_q4_0_ref(const float *src, block_q4_0 *dst, int k) {
+  assert(k % 32 == 0);
+  const int nb = k / 32;
+  for (int b = 0; b < nb; ++b) {
+    float amax = 0.0f;
+    for (int j = 0; j < 32; ++j) {
+      float v = std::fabs(src[b * 32 + j]);
+      if (v > amax) amax = v;
+    }
+    float d = amax / 8.0f;
+    float id = (d != 0.0f) ? (1.0f / d) : 0.0f;
+    dst[b].d = compute_fp32_to_fp16(d);
+
+    for (int j = 0; j < 16; ++j) {
+      float x0 = src[b * 32 + j]      * id;
+      float x1 = src[b * 32 + 16 + j] * id;
+      int q0 = (int)(x0 + 8.5f);
+      int q1 = (int)(x1 + 8.5f);
+      if (q0 < 0) q0 = 0; if (q0 > 15) q0 = 15;
+      if (q1 < 0) q1 = 0; if (q1 > 15) q1 = 15;
+      dst[b].qs[j] = (uint8_t)(q0 | (q1 << 4));
+    }
+  }
+}
+
+/**
+ * @brief Dequantize one block_q4_0 (32 elements) into float.
+ */
+static void dequantize_block_q4_0_ref(const block_q4_0 *blk, float *dst) {
+  float d = compute_fp16_to_fp32(blk->d);
+  for (int j = 0; j < 16; ++j) {
+    int q0 = (blk->qs[j] & 0x0F);
+    int q1 = (blk->qs[j] >> 4);
+    dst[j]      = ((float)q0 - 8.0f) * d;
+    dst[16 + j] = ((float)q1 - 8.0f) * d;
+  }
+}
+
+/**
+ * @brief Repack block_q4_0 data into x4x2 row-strided format for HMX.
+ *
+ * x4x2 row layout: [packed_quants (K/2 bytes) | scale_blocks]
+ * Each 256-element super-block has 8 groups packed into 128 quant bytes
+ * and 16 bytes of scales (8 x fp16).
+ *
+ * @param src_q4_0  Quantized blocks in block_q4_0 format [N * K/32 blocks]
+ * @param dst       Output buffer in x4x2 format
+ * @param N         Number of rows (output dimension)
+ * @param K         Number of columns (reduction dimension), must be % 256 == 0
+ * @return          Row stride in bytes
+ */
+static size_t repack_q4_0_to_x4x2(const block_q4_0 *src_q4_0, uint8_t *dst,
+                                   int N, int K) {
+  assert(K % 256 == 0);
+  const int groups_per_row = K / 32;
+  const int quants_per_row = K / 2;
+  const int n_superblocks = K / 256;
+  const int scales_per_row = n_superblocks * 16;
+  const size_t row_stride = (size_t)quants_per_row + scales_per_row;
+
+  for (int row = 0; row < N; ++row) {
+    uint8_t *dst_row = dst + row * row_stride;
+    uint8_t *dst_q = dst_row;
+    uint8_t *dst_s = dst_row + quants_per_row;
+    const block_q4_0 *src_row = src_q4_0 + row * groups_per_row;
+
+    for (int sb = 0; sb < n_superblocks; ++sb) {
+      uint8_t *sb_q = dst_q + sb * 128;
+      uint16_t *sb_s = (uint16_t *)(dst_s + sb * 16);
+
+      for (int g = 0; g < 8; ++g) {
+        const block_q4_0 *group = &src_row[sb * 8 + g];
+        int sub_blk = g / 4;
+        int sub_idx = g % 4;
+        memcpy(sb_q + sub_blk * 64 + sub_idx * 16, group->qs, 16);
+        sb_s[g] = group->d;
+      }
+    }
+  }
+  return row_stride;
+}
+
+/**
+ * @brief Run a single Q4_0 matmul test (x4x2 format) with the given
+ * dimensions.
+ *
+ * The test:
+ *   1. Generates random weight [N x K] in float
+ *   2. Quantizes each row to block_q4_0 format
+ *   3. Repacks block_q4_0 into x4x2 row-strided layout for HMX
+ *   4. Computes CPU reference: fp32 activation x dequant(Q4_0) weight
+ *   5. Calls htp_ops_mat_mul_af32_pwqk0_of32 on the DSP
+ *   6. Compares the DSP result against the CPU reference using MSE
+ *
+ * @param M  Number of output rows (batch dimension)
+ * @param K  Reduction dimension (must be multiple of 256 for x4x2)
+ * @param N  Number of output columns (must be multiple of 32)
+ */
+static void run_mat_mul_af32_pwqk0_of32_test(const uint32_t M,
+                                              const uint32_t K,
+                                              const uint32_t N) {
+  auto &htp = htp::HtpInterface::instance();
+
+  ASSERT_NE(htp.htp_ops_mat_mul_af32_pwqk0_of32, nullptr)
+    << "HTP library not loaded";
+
+  auto handle = htp.get_global_handle();
+  ASSERT_NE(handle, (uint64_t)0) << "DSP session not opened (handle == 0)";
+
+  ASSERT_EQ(K % 256, 0u) << "K must be multiple of 256 for x4x2 format";
+  ASSERT_EQ(N % 32, 0u) << "N must be multiple of 32";
+
+  // Generate random test data
+  std::vector<float> activation =
+    generate_random_vector<float, false>(M * K, -0.1f, 0.1f);
+  // Weight stored in [N x K] layout (row = output neuron)
+  std::vector<float> weight_f32 =
+    generate_random_vector<float, false>(N * K, -0.1f, 0.1f);
+
+  // Quantize each row of weight to block_q4_0
+  const int groups_per_row = K / 32;
+  std::vector<block_q4_0> weight_q4(N * groups_per_row);
+  for (uint32_t row = 0; row < N; ++row) {
+    quantize_row_q4_0_ref(weight_f32.data() + row * K,
+                          weight_q4.data() + row * groups_per_row, K);
+  }
+
+  // Dequantize for CPU reference
+  std::vector<float> weight_deq(N * K);
+  for (uint32_t row = 0; row < N; ++row) {
+    for (int g = 0; g < groups_per_row; ++g) {
+      dequantize_block_q4_0_ref(&weight_q4[row * groups_per_row + g],
+                                weight_deq.data() + row * K + g * 32);
+    }
+  }
+
+  // Compute reference: C[i,j] = sum_l A[i,l] * W_deq[j,l]
+  std::vector<float> ref_dst(M * N, 0.0f);
+  for (uint32_t i = 0; i < M; ++i) {
+    for (uint32_t j = 0; j < N; ++j) {
+      float sum = 0.0f;
+      for (uint32_t l = 0; l < K; ++l) {
+        sum += activation[i * K + l] * weight_deq[j * K + l];
+      }
+      ref_dst[i * N + j] = sum;
+    }
+  }
+
+  // Repack to x4x2 format
+  const int quants_per_row = K / 2;
+  const int n_superblocks = K / 256;
+  const size_t row_stride = (size_t)quants_per_row + n_superblocks * 16;
+  const size_t weight_x4x2_size = N * row_stride;
+  std::vector<uint8_t> weight_x4x2(weight_x4x2_size, 0);
+  size_t actual_stride =
+    repack_q4_0_to_x4x2(weight_q4.data(), weight_x4x2.data(), N, K);
+  ASSERT_EQ(actual_stride, row_stride);
+
+  // Allocate shared memory for DSP
+  float *output_ptr = nullptr;
+  float *activation_ptr = nullptr;
+  uint8_t *weight_ptr = nullptr;
+  int output_fd, activation_fd, weight_fd;
+
+  int err = htp.alloc_shared_mem_buf((void **)&output_ptr, &output_fd,
+                                     M * N * sizeof(float));
+  ASSERT_EQ(err, 0) << "Failed to allocate output buffer";
+
+  err = htp.alloc_shared_mem_buf((void **)&activation_ptr, &activation_fd,
+                                 M * K * sizeof(float));
+  ASSERT_EQ(err, 0) << "Failed to allocate activation buffer";
+
+  err = htp.alloc_shared_mem_buf((void **)&weight_ptr, &weight_fd,
+                                 weight_x4x2_size);
+  ASSERT_EQ(err, 0) << "Failed to allocate weight buffer";
+
+  // Copy data to shared buffers
+  memcpy(activation_ptr, activation.data(), M * K * sizeof(float));
+  memcpy(weight_ptr, weight_x4x2.data(), weight_x4x2_size);
+
+  // Run on DSP (weight_type = 2 for GGML_TYPE_Q4_0)
+  err = htp.htp_ops_mat_mul_af32_pwqk0_of32(handle, output_fd, 0,
+                                              activation_fd, 0, weight_fd, 0,
+                                              M, K, N, /*wgt_dt=*/2);
+  ASSERT_EQ(err, 0) << "htp_ops_mat_mul_af32_pwqk0_of32 failed";
+
+  // Compare results
+  std::vector<float> hmx_dst(M * N);
+  memcpy(hmx_dst.data(), output_ptr, M * N * sizeof(float));
+
+  float mse_err = mse<float>(hmx_dst.data(), ref_dst.data(), M * N);
+  std::cout << "Q4_0 x4x2 GEMM: " << M << " x " << K << " x " << N
+            << std::endl;
+  std::cout << " - MSE (vs Q4_0 dequant ref): " << mse_err << std::endl;
+
+  // Q4_0 has higher quantization error than fp16, allow larger threshold
+  EXPECT_IN_RANGE(mse_err, 0.0f, 0.05f);
+
+  // Cleanup
+  htp.free_shared_mem_buf(output_ptr, output_fd, M * N * sizeof(float));
+  htp.free_shared_mem_buf(activation_ptr, activation_fd,
+                          M * K * sizeof(float));
+  htp.free_shared_mem_buf(weight_ptr, weight_fd, weight_x4x2_size);
+}
+
+#define DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(M, K, N)                   \
+  TEST(nntrainer_htp_kernels, mat_mul_af32_pwqk0_of32_##M##_##K##_##N) {      \
+    run_mat_mul_af32_pwqk0_of32_test(M, K, N);                                \
+  }
+
+// Test square GEMM (K == N, K multiple of 256)
+DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(32, 256, 256);
+DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(32, 512, 512);
+DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(32, 1024, 1024);
+
+// Test rectangular GEMM
+DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(32, 256, 512);
+DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(32, 512, 256);
+DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(32, 1024, 256);
+DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(32, 256, 1024);
+
+// Test GEMV (M = 1)
+DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(1, 256, 256);
+DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(1, 512, 512);
+DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(1, 1024, 1024);
+DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(1, 256, 512);
+DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(1, 512, 256);
+
+// Test non-power-of-2 M dimensions
+DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(28, 256, 256);
+DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(68, 256, 512);
+DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(28, 512, 256);
+
+// Test large prefill-like dimensions (triggers out-stationary path)
+DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(128, 4096, 2048);
+
 #else
 
 TEST(nntrainer_htp_kernels, htp_not_enabled) {

--- a/test/unittest/unittest_htp_kernels.cpp
+++ b/test/unittest/unittest_htp_kernels.cpp
@@ -554,6 +554,141 @@ DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(28, 512, 256);
 // Test large prefill-like dimensions (triggers out-stationary path)
 DECLARE_mat_mul_af32_pwqk0_of32_test_M_K_N(128, 4096, 2048);
 
+/**
+ * @brief Simulate the quantizer's packing: block_q4_0 → block_q4_0x8 (with XOR)
+ */
+static void pack_q4_0_to_q4_0x8(const block_q4_0 *src, block_q4_0x8 *dst,
+                                 int N, int K) {
+  const int nblocks = K / QK4_0;
+  const uint64_t xor_mask = 0x8888888888888888ULL;
+
+  for (int b = 0; b < N; b += 8) {
+    for (int x = 0; x < nblocks; ++x) {
+      // Gather 8 rows' block x
+      block_q4_0 tmp[8];
+      for (int i = 0; i < 8; ++i) {
+        tmp[i] = src[(b + i) * nblocks + x];
+      }
+      // Pack with XOR mask (same as nntr_make_block_q4_0x8 in ggml_impl)
+      for (int i = 0; i < 8; ++i) dst->d[i] = tmp[i].d;
+      for (int i = 0; i < 16; ++i) {
+        int src_id = i % 8;
+        int src_off = (i / 8) * 8;
+        int dst_off = i * 8;
+        uint64_t elems;
+        memcpy(&elems, &tmp[src_id].qs[src_off], sizeof(uint64_t));
+        elems ^= xor_mask;
+        memcpy(&dst->qs[dst_off], &elems, sizeof(uint64_t));
+      }
+      dst++;
+    }
+  }
+}
+
+/**
+ * @brief Test that repackToX4x2_Q4_0x8 (block_q4_0x8 → x4x2) produces the
+ * same DSP results as the original path (block_q4_0 → x4x2).
+ */
+static void run_repack_q4_0x8_to_x4x2_test(const uint32_t M,
+                                             const uint32_t K,
+                                             const uint32_t N) {
+  auto &htp = htp::HtpInterface::instance();
+  ASSERT_NE(htp.htp_ops_mat_mul_af32_pwqk0_of32, nullptr);
+  auto handle = htp.get_global_handle();
+  ASSERT_NE(handle, (uint64_t)0);
+  ASSERT_EQ(K % 256, 0u);
+  ASSERT_EQ(N % 32, 0u);
+
+  // Generate data
+  std::vector<float> activation =
+    generate_random_vector<float, false>(M * K, -0.1f, 0.1f);
+  std::vector<float> weight_f32 =
+    generate_random_vector<float, false>(N * K, -0.1f, 0.1f);
+
+  // Quantize to block_q4_0
+  const int nblocks = K / 32;
+  std::vector<block_q4_0> weight_q4(N * nblocks);
+  for (uint32_t row = 0; row < N; ++row)
+    quantize_row_q4_0_ref(weight_f32.data() + row * K,
+                          weight_q4.data() + row * nblocks, K);
+
+  // Pack to block_q4_0x8 (simulates quantizer)
+  std::vector<block_q4_0x8> weight_x8((N / 8) * nblocks);
+  pack_q4_0_to_q4_0x8(weight_q4.data(), weight_x8.data(), N, K);
+
+  // Path A: block_q4_0 → x4x2 (direct, known-good)
+  size_t row_stride = (size_t)(K / 2) + (size_t)(K / 256) * 16;
+  size_t wt_size = N * row_stride;
+  std::vector<uint8_t> x4x2_A(wt_size, 0);
+  repack_q4_0_to_x4x2(weight_q4.data(), x4x2_A.data(), N, K);
+
+  // Path B: block_q4_0x8 → x4x2 (new direct function)
+  std::vector<uint8_t> x4x2_B(wt_size, 0);
+  size_t actual_stride = 0;
+  nntrainer::Q4_0Utils::repackToX4x2_Q4_0x8(weight_x8.data(), x4x2_B.data(),
+                                              N, K, &actual_stride);
+  ASSERT_EQ(actual_stride, row_stride);
+
+  // Compare the two x4x2 outputs byte-for-byte
+  EXPECT_EQ(x4x2_A, x4x2_B)
+    << "repackToX4x2_Q4_0x8 output differs from repackToX4x2_Q4_0 output";
+
+  // Also verify DSP produces correct results via path B
+  std::vector<float> weight_deq(N * K);
+  for (uint32_t row = 0; row < N; ++row)
+    for (int g = 0; g < nblocks; ++g)
+      dequantize_block_q4_0_ref(&weight_q4[row * nblocks + g],
+                                weight_deq.data() + row * K + g * 32);
+
+  std::vector<float> ref_dst(M * N, 0.0f);
+  for (uint32_t i = 0; i < M; ++i)
+    for (uint32_t j = 0; j < N; ++j) {
+      float sum = 0.0f;
+      for (uint32_t l = 0; l < K; ++l)
+        sum += activation[i * K + l] * weight_deq[j * K + l];
+      ref_dst[i * N + j] = sum;
+    }
+
+  float *output_ptr = nullptr;
+  float *act_ptr = nullptr;
+  uint8_t *wt_ptr = nullptr;
+  int out_fd, act_fd, wt_fd;
+  ASSERT_EQ(htp.alloc_shared_mem_buf((void **)&output_ptr, &out_fd,
+                                      M * N * sizeof(float)), 0);
+  ASSERT_EQ(htp.alloc_shared_mem_buf((void **)&act_ptr, &act_fd,
+                                      M * K * sizeof(float)), 0);
+  ASSERT_EQ(htp.alloc_shared_mem_buf((void **)&wt_ptr, &wt_fd, wt_size), 0);
+
+  memcpy(act_ptr, activation.data(), M * K * sizeof(float));
+  memcpy(wt_ptr, x4x2_B.data(), wt_size);
+
+  int err = htp.htp_ops_mat_mul_af32_pwqk0_of32(handle, out_fd, 0, act_fd, 0,
+                                                  wt_fd, 0, M, K, N, 2);
+  ASSERT_EQ(err, 0);
+
+  std::vector<float> hmx_dst(M * N);
+  memcpy(hmx_dst.data(), output_ptr, M * N * sizeof(float));
+
+  float mse_err = mse<float>(hmx_dst.data(), ref_dst.data(), M * N);
+  std::cout << "Q4_0x8→x4x2 GEMM: " << M << "x" << K << "x" << N
+            << "  MSE=" << mse_err << std::endl;
+  EXPECT_IN_RANGE(mse_err, 0.0f, 0.05f);
+
+  htp.free_shared_mem_buf(output_ptr, out_fd, M * N * sizeof(float));
+  htp.free_shared_mem_buf(act_ptr, act_fd, M * K * sizeof(float));
+  htp.free_shared_mem_buf(wt_ptr, wt_fd, wt_size);
+}
+
+#define DECLARE_repack_q4_0x8_test(M, K, N)                                    \
+  TEST(nntrainer_htp_kernels, repack_q4_0x8_to_x4x2_##M##_##K##_##N) {        \
+    run_repack_q4_0x8_to_x4x2_test(M, K, N);                                  \
+  }
+
+DECLARE_repack_q4_0x8_test(32, 256, 256);
+DECLARE_repack_q4_0x8_test(1, 512, 512);
+DECLARE_repack_q4_0x8_test(32, 1024, 256);
+DECLARE_repack_q4_0x8_test(128, 4096, 2048);
+
 #else
 
 TEST(nntrainer_htp_kernels, htp_not_enabled) {

--- a/test/unittest/unittest_htp_kernels.cpp
+++ b/test/unittest/unittest_htp_kernels.cpp
@@ -16,6 +16,7 @@
 #include <fp16.h>
 #include <htp_interface.h>
 #include <nntrainer_test_util.h>
+#include <q4_0_utils.h>
 
 using namespace nntrainer;
 


### PR DESCRIPTION
## Summary
- Convert Q4_0 HTP matmul kernel from old format to Qualcomm's x4x2 weight layout
  with correct scalar dequantization
- Add host-side weight repacking from block_q4_0x4 (ARM) to x4x2 row-strided format
- Implement HTP Q4_0 path in dotQnK for model inference (float_tensor.cpp)
- Fix out-stationary K-blocking with k_offset/full_k parameters
- Add comprehensive unit tests including block_q4_0x4 → x4x2 conversion validation

## Key changes
- `mat_mul.c`: x4x2 dequant kernel, 2D DMA, per-tile mxclracc
- `q4_0_utils.cpp/h`: repackToX4x2_Q4_0, repackToX4x2_Q4_0x4, repackToX4x2_Q4_0x8
- `float_tensor.cpp`: HTP Q4_0 path using block_q4_0x4 format (ARM-specific)
- `unittest_htp_kernels.cpp`: 20 new test cases

## Test plan
- [ ] All Q4_0 x4x2 unit tests pass (16 matmul + 4 repack validation)
- [ ] qwen3-0.6b-w4a32 model inference produces correct results via HTP
