### PR TITLE
Add HTP rms_norm kernel and dispatch from CausalLM layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ test/jni/googletest/
 ctre-unicode.hpp
 encoder.hpp
 json.hpp
+subprojects/.wraplock

--- a/Applications/CausalLM/jni/Android.mk
+++ b/Applications/CausalLM/jni/Android.mk
@@ -102,6 +102,9 @@ LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
 LOCAL_STATIC_LIBRARIES := tokenizers_c
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES) $(CAUSALLM_COMMON_INCLUDES)
+ifeq ($(ENABLE_HTP),1)
+LOCAL_C_INCLUDES += $(NNTRAINER_ROOT)/nntrainer/tensor/htp_backend
+endif
 
 include $(BUILD_SHARED_LIBRARY)
 

--- a/Applications/CausalLM/layers/reshaped_rms_norm.cpp
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.cpp
@@ -12,8 +12,13 @@
  */
 
 #include <cmath>
+#include <cstring>
 #include <cpu_backend.h>
 #include <reshaped_rms_norm.h>
+
+#if defined(ENABLE_HTP) && ENABLE_HTP == 1
+#include <htp_interface.h>
+#endif
 
 namespace causallm {
 
@@ -82,17 +87,67 @@ void ReshapedRMSNormLayer::incremental_forwarding(
     out_step.reshape(step_reshaped_dim);
 
     if (in_step.getDataType() == ml::train::TensorDim::DataType::FP32) {
-      ///@todo rms_norm_wrt_width_something() should be refactored to
-      /// nntrainer::Tensor operation.
-#ifdef ENABLE_FP16
-      nntrainer::rms_norm_wrt_width_fp16_intrinsic(
-        in_step.getData<float>(), out_step.getData<float>(),
-        in_step.getDim().height(), in_step.getDim().width(), epsilon);
-#else
-      nntrainer::rms_norm_wrt_width_fp32_intrinsic(
-        in_step.getData<float>(), out_step.getData<float>(),
-        in_step.getDim().height(), in_step.getDim().width(), epsilon);
+      bool htp_done = false;
+      const int ne0 = static_cast<int>(in_step.getDim().width());
+      const int ne1 = static_cast<int>(in_step.getDim().height());
+
+#if defined(ENABLE_HTP) && ENABLE_HTP == 1
+      {
+        auto &htp = nntrainer::htp::HtpInterface::instance();
+        if (htp.htp_ops_rms_norm_f32 && htp.alloc_shared_mem_buf &&
+            htp.free_shared_mem_buf && htp.get_global_handle) {
+          auto handle = htp.get_global_handle();
+          if (handle != 0) {
+            float eps_f = epsilon;
+            int32_t eps_bits;
+            std::memcpy(&eps_bits, &eps_f, sizeof(float));
+
+            // HVX writes/reads up to VLEN=32 floats past the end of the last
+            // row; reserve padding only for the final row.
+            const int ne0_padded = ((ne0 + 31) / 32) * 32;
+            const size_t buf_elems = static_cast<size_t>(
+              (ne1 > 0 ? (ne1 - 1) * ne0 : 0) + ne0_padded);
+            const size_t buf_size = buf_elems * sizeof(float);
+            const size_t total_size = buf_size * 2; // src + dst back-to-back
+
+            void *io_buf = nullptr;
+            int io_fd = -1;
+            int err = htp.alloc_shared_mem_buf(&io_buf, &io_fd, total_size);
+            if (err == 0 && io_buf) {
+              char *base = static_cast<char *>(io_buf);
+              std::memset(base, 0, total_size);
+              std::memcpy(base, in_step.getData<float>(),
+                          static_cast<size_t>(ne0) * ne1 * sizeof(float));
+
+              err = htp.htp_ops_rms_norm_f32(
+                handle, io_fd, static_cast<int>(buf_size), io_fd, 0, ne0, ne1,
+                eps_bits);
+
+              if (err == 0) {
+                std::memcpy(out_step.getData<float>(), base + buf_size,
+                            static_cast<size_t>(ne0) * ne1 * sizeof(float));
+                htp_done = true;
+              }
+              htp.free_shared_mem_buf(io_buf, io_fd, total_size);
+            }
+          }
+        }
+      }
 #endif
+
+      if (!htp_done) {
+        ///@todo rms_norm_wrt_width_something() should be refactored to
+        /// nntrainer::Tensor operation.
+#ifdef ENABLE_FP16
+        nntrainer::rms_norm_wrt_width_fp16_intrinsic(
+          in_step.getData<float>(), out_step.getData<float>(),
+          in_step.getDim().height(), in_step.getDim().width(), epsilon);
+#else
+        nntrainer::rms_norm_wrt_width_fp32_intrinsic(
+          in_step.getData<float>(), out_step.getData<float>(),
+          in_step.getDim().height(), in_step.getDim().width(), epsilon);
+#endif
+      }
     } else {
       throw std::invalid_argument(
         "Error: not yet implemented for this data type");

--- a/Applications/CausalLM/layers/rms_norm.cpp
+++ b/Applications/CausalLM/layers/rms_norm.cpp
@@ -12,9 +12,14 @@
  */
 
 #include <cmath>
+#include <cstring>
 #include <iostream>
 
 #include "rms_norm.h"
+
+#if defined(ENABLE_HTP) && ENABLE_HTP == 1
+#include <htp_interface.h>
+#endif
 
 namespace causallm {
 
@@ -66,9 +71,59 @@ void RMSNormLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
       out.getSharedDataTensor(out_step_dim, b * out_dim.getFeatureLen(), true);
 
     if (in_step.getDataType() == ml::train::TensorDim::DataType::FP32) {
-      auto t = in_step.multiply(in_step).average(3).add(epsilon);
-      t.inv_sqrt_i();
-      in_step.multiply(t, out_step);
+      bool htp_done = false;
+      const int ne0 = static_cast<int>(in_step.getDim().width());
+      const int ne1 = static_cast<int>(in_step.getDim().height());
+
+#if defined(ENABLE_HTP) && ENABLE_HTP == 1
+      {
+        auto &htp = nntrainer::htp::HtpInterface::instance();
+        if (htp.htp_ops_rms_norm_f32 && htp.alloc_shared_mem_buf &&
+            htp.free_shared_mem_buf && htp.get_global_handle) {
+          auto handle = htp.get_global_handle();
+          if (handle != 0) {
+            float eps_f = epsilon;
+            int32_t eps_bits;
+            std::memcpy(&eps_bits, &eps_f, sizeof(float));
+
+            // HVX writes/reads up to VLEN=32 floats past the end of the last
+            // row; reserve padding only for the final row.
+            const int ne0_padded = ((ne0 + 31) / 32) * 32;
+            const size_t buf_elems = static_cast<size_t>(
+              (ne1 > 0 ? (ne1 - 1) * ne0 : 0) + ne0_padded);
+            const size_t buf_size = buf_elems * sizeof(float);
+            const size_t total_size = buf_size * 2; // src + dst back-to-back
+
+            void *io_buf = nullptr;
+            int io_fd = -1;
+            int err = htp.alloc_shared_mem_buf(&io_buf, &io_fd, total_size);
+            if (err == 0 && io_buf) {
+              char *base = static_cast<char *>(io_buf);
+              std::memset(base, 0, total_size);
+              std::memcpy(base, in_step.getData<float>(),
+                          static_cast<size_t>(ne0) * ne1 * sizeof(float));
+
+              err = htp.htp_ops_rms_norm_f32(
+                handle, io_fd, static_cast<int>(buf_size), io_fd, 0, ne0, ne1,
+                eps_bits);
+
+              if (err == 0) {
+                std::memcpy(out_step.getData<float>(), base + buf_size,
+                            static_cast<size_t>(ne0) * ne1 * sizeof(float));
+                htp_done = true;
+              }
+              htp.free_shared_mem_buf(io_buf, io_fd, total_size);
+            }
+          }
+        }
+      }
+#endif
+
+      if (!htp_done) {
+        auto t = in_step.multiply(in_step).average(3).add(epsilon);
+        t.inv_sqrt_i();
+        in_step.multiply(t, out_step);
+      }
     } else {
       throw std::invalid_argument(
         "Error: not yet implemented for this data type");

--- a/nntrainer/tensor/htp_backend/host/op_export.c
+++ b/nntrainer/tensor/htp_backend/host/op_export.c
@@ -3,8 +3,8 @@
 #include "host/session.h"
 #include "host/htp_ops.h"
 
-int htp_ops_rpc_rms_norm_f32(int dst_fd, int dst_offset, int src_fd, int src_offset, int ne0, int ne1) {
-  return htp_ops_rms_norm_f32(get_global_handle(), dst_fd, dst_offset, src_fd, src_offset, ne0, ne1);
+int htp_ops_rpc_rms_norm_f32(int dst_fd, int dst_offset, int src_fd, int src_offset, int ne0, int ne1, int eps_bits) {
+  return htp_ops_rms_norm_f32(get_global_handle(), dst_fd, dst_offset, src_fd, src_offset, ne0, ne1, eps_bits);
 }
 
 int htp_ops_rpc_mat_mul_af32_pwf16_of32(int output_fd, int output_offset, int activation_fd, int activation_offset,

--- a/nntrainer/tensor/htp_backend/host/test.c
+++ b/nntrainer/tensor/htp_backend/host/test.c
@@ -71,7 +71,10 @@ static void test_rms_norm_f32_rpc(remote_handle64 handle, int ne0) {
   }
 
   int64_t t0             = get_time_us();
-  err                    = htp_ops_rms_norm_f32(handle, fd_dst, 0, fd_src, 0, ne0, 1);
+  float test_eps = 1e-5f;
+  int32_t test_eps_bits;
+  memcpy(&test_eps_bits, &test_eps, sizeof(float));
+  err                    = htp_ops_rms_norm_f32(handle, fd_dst, 0, fd_src, 0, ne0, 1, test_eps_bits);
   int64_t rpc_elapsed_us = get_time_us() - t0;
   fprintf(stderr, "rms_norm_f32 RPC took %ld us\n", rpc_elapsed_us);
 
@@ -140,11 +143,15 @@ static void test_rms_norm_f32_chan(void *chan, int ne0) {
     struct OpComputeRequest compute_req = {
       .op = HTP_OPS_RMS_NORM_F32,
     };
+    float chan_eps = 1e-5f;
+    int32_t chan_eps_bits;
+    memcpy(&chan_eps_bits, &chan_eps, sizeof(float));
     struct RmsNormF32Params params = {
       .dst = { .fd = fd_dst, .offset = 0, },
       .src = { .fd = fd_src, .offset = 0, },
       .ne0 = ne0,
       .ne1 = 1,
+      .eps_bits = chan_eps_bits,
     };
 
     size_t req_size     = sizeof(req_hdr) + sizeof(compute_req) + sizeof(params);

--- a/nntrainer/tensor/htp_backend/htp/commu.c
+++ b/nntrainer/tensor/htp_backend/htp/commu.c
@@ -265,7 +265,7 @@ AEEResult htp_ops_destroy_channel(remote_handle64 handle) {
 
 // FastRPC interface
 AEEResult htp_ops_rms_norm_f32(remote_handle64 handle, int32 fd0, int32 offset0, int32 fd1, int32 offset1, int32 ne0,
-                               int32 ne1) {
+                               int32 ne1, int32 eps_bits) {
   int64_t t0 = HAP_perf_get_qtimer_count();
 
   // TODO(hzx): maybe we should cache fd -> address mapping
@@ -290,8 +290,11 @@ AEEResult htp_ops_rms_norm_f32(remote_handle64 handle, int32 fd0, int32 offset0,
   size_t       input_size = ne0 * ne1 * sizeof(float);  // This can be inaccurate
   qurt_mem_cache_clean((qurt_addr_t) input, input_size, QURT_MEM_CACHE_INVALIDATE, QURT_MEM_DCACHE);
 
+  float eps;
+  memcpy(&eps, &eps_bits, sizeof(float));
+
   float *output = (float *) (p0 + offset0);
-  err           = hvx_rms_norm_f32(output, input, ne0, ne1);
+  err           = hvx_rms_norm_f32(output, input, ne0, ne1, eps);
   if (err) {
     FARF(ALWAYS, "%s: bad input or alignment", __func__);
     goto bail;

--- a/nntrainer/tensor/htp_backend/htp/hvx_ops/rms_norm.c
+++ b/nntrainer/tensor/htp_backend/htp/hvx_ops/rms_norm.c
@@ -5,9 +5,7 @@
 #define PREFETCH_SIZE   (8 * 1024)
 #define PREFETCH_N_VECS (PREFETCH_SIZE / VLEN)
 
-void hvx_rms_norm_f32_inner(float *restrict dst, const float *restrict src, int ne0) {
-  // TODO(hzx): make eps an input
-  const float eps = 1e-5;
+void hvx_rms_norm_f32_inner(float *restrict dst, const float *restrict src, int ne0, float eps) {
 
   int n_vecs        = ne0 / 32;
   int leftover      = ne0 & 31;
@@ -65,7 +63,7 @@ void hvx_rms_norm_f32_inner(float *restrict dst, const float *restrict src, int 
   }
 }
 
-int hvx_rms_norm_f32(float *restrict dst, const float *restrict src, int ne0, int ne1) {
+int hvx_rms_norm_f32(float *restrict dst, const float *restrict src, int ne0, int ne1, float eps) {
   if (!dst || !src || !ne0 || !ne1) {
     return -1;
   }
@@ -77,7 +75,7 @@ int hvx_rms_norm_f32(float *restrict dst, const float *restrict src, int ne0, in
   for (int j = 0; j < ne1; ++j) {
     float       *output = dst + j * ne0;
     const float *input  = src + j * ne0;
-    hvx_rms_norm_f32_inner(output, input, ne0);
+    hvx_rms_norm_f32_inner(output, input, ne0, eps);
   }
 
   return 0;

--- a/nntrainer/tensor/htp_backend/htp/op_executor.cc
+++ b/nntrainer/tensor/htp_backend/htp/op_executor.cc
@@ -74,7 +74,9 @@ int execute_op_simple(struct OpComputeRequest *req) {
         add_buffer(in_bufs, params->src, size);
 
         validate_in_bufs();
-        ret = hvx_rms_norm_f32((float *) OUT_PTR(0), (const float *) IN_PTR(0), params->ne0, params->ne1);
+        float eps;
+        memcpy(&eps, &params->eps_bits, sizeof(float));
+        ret = hvx_rms_norm_f32((float *) OUT_PTR(0), (const float *) IN_PTR(0), params->ne0, params->ne1, eps);
         validate_out_bufs();
       }
       break;

--- a/nntrainer/tensor/htp_backend/htp_interface.h
+++ b/nntrainer/tensor/htp_backend/htp_interface.h
@@ -36,6 +36,8 @@ using htp_ops_mat_mul_af32_wf16_of32_fn_t =
   int(remote_handle64, int, int, int, int, int, int, int, int, int);
 using htp_ops_mat_mul_af32_pwqk0_of32_fn_t =
   int(remote_handle64, int, int, int, int, int, int, int, int, int, int);
+using htp_ops_rms_norm_f32_fn_t =
+  int(remote_handle64, int, int, int, int, int, int);
 
 /**
  * @brief Singleton interface that loads libhtp_ops.so at runtime and resolves
@@ -56,6 +58,7 @@ struct HtpInterface {
   htp_ops_mat_mul_af32_pwf16_of32_fn_t *htp_ops_mat_mul_af32_pwf16_of32 = nullptr;
   htp_ops_mat_mul_af32_wf16_of32_fn_t *htp_ops_mat_mul_af32_wf16_of32 = nullptr;
   htp_ops_mat_mul_af32_pwqk0_of32_fn_t *htp_ops_mat_mul_af32_pwqk0_of32 = nullptr;
+  htp_ops_rms_norm_f32_fn_t *htp_ops_rms_norm_f32 = nullptr;
 
   static HtpInterface &instance() {
     static HtpInterface inst = load();
@@ -104,6 +107,8 @@ private:
     iface.htp_ops_mat_mul_af32_pwqk0_of32 =
       sym<htp_ops_mat_mul_af32_pwqk0_of32_fn_t>(
         lib, "htp_ops_mat_mul_af32_pwqk0_of32");
+    iface.htp_ops_rms_norm_f32 =
+      sym<htp_ops_rms_norm_f32_fn_t>(lib, "htp_ops_rms_norm_f32");
 
     return iface;
   }

--- a/nntrainer/tensor/htp_backend/htp_interface.h
+++ b/nntrainer/tensor/htp_backend/htp_interface.h
@@ -37,7 +37,7 @@ using htp_ops_mat_mul_af32_wf16_of32_fn_t =
 using htp_ops_mat_mul_af32_pwqk0_of32_fn_t =
   int(remote_handle64, int, int, int, int, int, int, int, int, int, int);
 using htp_ops_rms_norm_f32_fn_t =
-  int(remote_handle64, int, int, int, int, int, int);
+  int(remote_handle64, int, int, int, int, int, int, int);
 
 /**
  * @brief Singleton interface that loads libhtp_ops.so at runtime and resolves

--- a/nntrainer/tensor/htp_backend/include/host/htp_ops.h
+++ b/nntrainer/tensor/htp_backend/include/host/htp_ops.h
@@ -256,7 +256,7 @@ __QAIC_HEADER_EXPORT int __QAIC_HEADER(htp_ops_close)(remote_handle64 h) __QAIC_
 __QAIC_HEADER_EXPORT AEEResult __QAIC_HEADER(htp_ops_init_backend)(remote_handle64 _h) __QAIC_HEADER_ATTRIBUTE;
 __QAIC_HEADER_EXPORT AEEResult __QAIC_HEADER(htp_ops_create_channel)(remote_handle64 _h, int32 fd, uint32 size) __QAIC_HEADER_ATTRIBUTE;
 __QAIC_HEADER_EXPORT AEEResult __QAIC_HEADER(htp_ops_destroy_channel)(remote_handle64 _h) __QAIC_HEADER_ATTRIBUTE;
-__QAIC_HEADER_EXPORT AEEResult __QAIC_HEADER(htp_ops_rms_norm_f32)(remote_handle64 _h, int32 fd0, int32 offset0, int32 fd1, int32 offset1, int32 ne0, int32 ne1) __QAIC_HEADER_ATTRIBUTE;
+__QAIC_HEADER_EXPORT AEEResult __QAIC_HEADER(htp_ops_rms_norm_f32)(remote_handle64 _h, int32 fd0, int32 offset0, int32 fd1, int32 offset1, int32 ne0, int32 ne1, int32 eps_bits) __QAIC_HEADER_ATTRIBUTE;
 __QAIC_HEADER_EXPORT AEEResult __QAIC_HEADER(htp_ops_mat_mul_af32_pwf16_of32)(remote_handle64 _h, int32 fd0, int32 offset0, int32 fd1, int32 offset1, int32 fd2, int32 offset2, int32 m, int32 k, int32 n) __QAIC_HEADER_ATTRIBUTE;
 __QAIC_HEADER_EXPORT AEEResult __QAIC_HEADER(htp_ops_mat_mul_af32_wf16_of32)(remote_handle64 _h, int32 fd0, int32 offset0, int32 fd1, int32 offset1, int32 fd2, int32 offset2, int32 m, int32 k, int32 n) __QAIC_HEADER_ATTRIBUTE;
 __QAIC_HEADER_EXPORT AEEResult __QAIC_HEADER(htp_ops_mat_mul_af32_pwqk0_of32)(remote_handle64 _h, int32 fd0, int32 offset0, int32 fd1, int32 offset1, int32 fd2, int32 offset2, int32 m, int32 k, int32 n, int32 wgt_dt) __QAIC_HEADER_ATTRIBUTE;

--- a/nntrainer/tensor/htp_backend/include/host/htp_ops_skel.c
+++ b/nntrainer/tensor/htp_backend/include/host/htp_ops_skel.c
@@ -370,7 +370,7 @@ static __inline int _skel_method_2(int (*_pfn)(remote_handle64, int32, int32, in
    _QAIC_CATCH(_nErr) {}
    return _nErr;
 }
-static __inline int _skel_method_3(int (*_pfn)(remote_handle64, int32, int32, int32, int32, int32, int32), remote_handle64 _h, uint32_t _sc, remote_arg* _pra) {
+static __inline int _skel_method_3(int (*_pfn)(remote_handle64, int32, int32, int32, int32, int32, int32, int32), remote_handle64 _h, uint32_t _sc, remote_arg* _pra) {
    remote_arg* _praEnd = 0;
    uint32_t _in0[1] = {0};
    uint32_t _in1[1] = {0};
@@ -378,6 +378,7 @@ static __inline int _skel_method_3(int (*_pfn)(remote_handle64, int32, int32, in
    uint32_t _in3[1] = {0};
    uint32_t _in4[1] = {0};
    uint32_t _in5[1] = {0};
+   uint32_t _in6[1] = {0};
    uint32_t* _primIn= 0;
    int _nErr = 0;
    _praEnd = ((_pra + REMOTE_SCALARS_INBUFS(_sc)) + REMOTE_SCALARS_OUTBUFS(_sc) + REMOTE_SCALARS_INHANDLES(_sc) + REMOTE_SCALARS_OUTHANDLES(_sc));
@@ -386,7 +387,7 @@ static __inline int _skel_method_3(int (*_pfn)(remote_handle64, int32, int32, in
    _QAIC_ASSERT(_nErr, REMOTE_SCALARS_INHANDLES(_sc)==0);
    _QAIC_ASSERT(_nErr, REMOTE_SCALARS_OUTHANDLES(_sc)==0);
    _QAIC_ASSERT(_nErr, (_pra + ((1 + 0) + (((0 + 0) + 0) + 0))) <= _praEnd);
-   _QAIC_ASSERT(_nErr, _pra[0].buf.nLen >= 24);
+   _QAIC_ASSERT(_nErr, _pra[0].buf.nLen >= 28);
    _primIn = _pra[0].buf.pv;
    _COPY(_in0, 0, _primIn, 0, 4);
    _COPY(_in1, 0, _primIn, 4, 4);
@@ -394,7 +395,8 @@ static __inline int _skel_method_3(int (*_pfn)(remote_handle64, int32, int32, in
    _COPY(_in3, 0, _primIn, 12, 4);
    _COPY(_in4, 0, _primIn, 16, 4);
    _COPY(_in5, 0, _primIn, 20, 4);
-   _TRY(_nErr, _pfn(_h, (int32)*_in0, (int32)*_in1, (int32)*_in2, (int32)*_in3, (int32)*_in4, (int32)*_in5));
+   _COPY(_in6, 0, _primIn, 24, 4);
+   _TRY(_nErr, _pfn(_h, (int32)*_in0, (int32)*_in1, (int32)*_in2, (int32)*_in3, (int32)*_in4, (int32)*_in5, (int32)*_in6));
    _QAIC_CATCH(_nErr) {}
    return _nErr;
 }

--- a/nntrainer/tensor/htp_backend/include/host/htp_ops_stub.c
+++ b/nntrainer/tensor/htp_backend/include/host/htp_ops_stub.c
@@ -345,9 +345,28 @@ static __inline int _stub_method_2(remote_handle64 _handle, uint32_t _mid, uint3
    }
    return _nErr;
 }
-__QAIC_STUB_EXPORT AEEResult __QAIC_STUB(htp_ops_rms_norm_f32)(remote_handle64 _handle, int32 fd0, int32 offset0, int32 fd1, int32 offset1, int32 ne0, int32 ne1) __QAIC_STUB_ATTRIBUTE {
+static __inline int _stub_method_2b(remote_handle64 _handle, uint32_t _mid, uint32_t _in0[1], uint32_t _in1[1], uint32_t _in2[1], uint32_t _in3[1], uint32_t _in4[1], uint32_t _in5[1], uint32_t _in6[1]) {
+   remote_arg _pra[1] = {0};
+   uint32_t _primIn[7]= {0};
+   int _nErr = 0;
+   _pra[0].buf.pv = (void*)_primIn;
+   _pra[0].buf.nLen = sizeof(_primIn);
+   _COPY(_primIn, 0, _in0, 0, 4);
+   _COPY(_primIn, 4, _in1, 0, 4);
+   _COPY(_primIn, 8, _in2, 0, 4);
+   _COPY(_primIn, 12, _in3, 0, 4);
+   _COPY(_primIn, 16, _in4, 0, 4);
+   _COPY(_primIn, 20, _in5, 0, 4);
+   _COPY(_primIn, 24, _in6, 0, 4);
+   _TRY_FARF(_nErr, __QAIC_REMOTE(remote_handle64_invoke)(_handle, REMOTE_SCALARS_MAKEX(0, _mid, 1, 0, 0, 0), _pra));
+   _CATCH_FARF(_nErr) {
+      _QAIC_FARF(RUNTIME_ERROR, "ERROR 0x%x: handle=0x%"PRIx64", scalar=0x%x, method ID=%d: %s failed\n", _nErr , _handle, REMOTE_SCALARS_MAKEX(0, _mid, 1, 0, 0, 0), _mid, __func__);
+   }
+   return _nErr;
+}
+__QAIC_STUB_EXPORT AEEResult __QAIC_STUB(htp_ops_rms_norm_f32)(remote_handle64 _handle, int32 fd0, int32 offset0, int32 fd1, int32 offset1, int32 ne0, int32 ne1, int32 eps_bits) __QAIC_STUB_ATTRIBUTE {
    uint32_t _mid = 5;
-   return _stub_method_2(_handle, _mid, (uint32_t*)&fd0, (uint32_t*)&offset0, (uint32_t*)&fd1, (uint32_t*)&offset1, (uint32_t*)&ne0, (uint32_t*)&ne1);
+   return _stub_method_2b(_handle, _mid, (uint32_t*)&fd0, (uint32_t*)&offset0, (uint32_t*)&fd1, (uint32_t*)&offset1, (uint32_t*)&ne0, (uint32_t*)&ne1, (uint32_t*)&eps_bits);
 }
 static __inline int _stub_method_3(remote_handle64 _handle, uint32_t _mid, uint32_t _in0[1], uint32_t _in1[1], uint32_t _in2[1], uint32_t _in3[1], uint32_t _in4[1], uint32_t _in5[1], uint32_t _in6[1], uint32_t _in7[1], uint32_t _in8[1]) {
    remote_arg _pra[1] = {0};

--- a/nntrainer/tensor/htp_backend/include/host/op_export.h
+++ b/nntrainer/tensor/htp_backend/include/host/op_export.h
@@ -1,6 +1,6 @@
 #pragma once
 
-int htp_ops_rpc_rms_norm_f32(int dst_fd, int dst_offset, int src_fd, int src_offset, int ne0, int ne1);
+int htp_ops_rpc_rms_norm_f32(int dst_fd, int dst_offset, int src_fd, int src_offset, int ne0, int ne1, int eps_bits);
 
 int htp_ops_rpc_mat_mul_af32_pwf16_of32(int output_fd, int output_offset, int activation_fd, int activation_offset,
                                         int weight_fd, int weight_offset, int m, int k, int n);

--- a/nntrainer/tensor/htp_backend/include/htp/ops.h
+++ b/nntrainer/tensor/htp_backend/include/htp/ops.h
@@ -17,7 +17,7 @@ int hmx_mat_mul_af32_pwf16_of32(float *restrict out, const float *act, const __f
 int hmx_mat_mul_af32_wf16_of32(float *restrict out, const float *restrict act, const __fp16 *restrict wgt, int m, int k, int n);
 int hmx_mat_mul_af32_pwqk0_of32(float *restrict dst, const float *activation, const uint8_t *permuted_weight, int m, int k, int n, size_t weight_row_stride, enum ggml_type weight_type);
 
-int hvx_rms_norm_f32(float *restrict dst, const float *restrict src, int ne0, int ne1);
+int hvx_rms_norm_f32(float *restrict dst, const float *restrict src, int ne0, int ne1, float eps);
 
 int simple_flash_attn(__fp16 *restrict O, const __fp16 *restrict Q, const __fp16 *restrict K, const __fp16 *restrict V,
                       const __fp16 *restrict mask, int qo_len, int kv_len, int n_heads, int n_kv_heads, int head_dim);

--- a/nntrainer/tensor/htp_backend/include/htp_ops.idl
+++ b/nntrainer/tensor/htp_backend/include/htp_ops.idl
@@ -12,7 +12,7 @@ interface htp_ops : remote_handle64 {
     AEEResult destroy_channel();
 
     /* ops RPC interface */
-    AEEResult rms_norm_f32(in int32 fd0, in int32 offset0, in int32 fd1, in int32 offset1, in int32 ne0, in int32 ne1);
+    AEEResult rms_norm_f32(in int32 fd0, in int32 offset0, in int32 fd1, in int32 offset1, in int32 ne0, in int32 ne1, in int32 eps_bits);
     AEEResult mat_mul_af32_pwf16_of32(in int32 fd0, in int32 offset0, in int32 fd1, in int32 offset1, in int32 fd2, in int32 offset2,
         in int32 m, in int32 k, in int32 n);
     AEEResult mat_mul_af32_wf16_of32(in int32 fd0, in int32 offset0, in int32 fd1, in int32 offset1, in int32 fd2, in int32 offset2,

--- a/nntrainer/tensor/htp_backend/include/op_reg.h
+++ b/nntrainer/tensor/htp_backend/include/op_reg.h
@@ -22,6 +22,7 @@ struct RmsNormF32Params {
   struct RpcmemBufAddr src;
   int32_t       ne0;
   int32_t       ne1;
+  int32_t       eps_bits;
 } __attribute__((packed));
 
 struct MatMulParams {

--- a/test/unittest/unittest_htp_kernels.cpp
+++ b/test/unittest/unittest_htp_kernels.cpp
@@ -701,9 +701,10 @@ DECLARE_repack_q4_0x4_test(128, 4096, 2048);
  * @param src  Input buffer  [ne1 x ne0]
  * @param ne0  Number of elements per row (feature dimension)
  * @param ne1  Number of rows
+ * @param eps  Epsilon for numerical stability
  */
-static void rms_norm_f32_ref(float *dst, const float *src, int ne0, int ne1) {
-  const float eps = 1e-5f;
+static void rms_norm_f32_ref(float *dst, const float *src, int ne0, int ne1,
+                             float eps) {
   for (int j = 0; j < ne1; ++j) {
     const float *x = src + j * ne0;
     float       *y = dst + j * ne0;
@@ -720,18 +721,20 @@ static void rms_norm_f32_ref(float *dst, const float *src, int ne0, int ne1) {
 }
 
 /**
- * @brief Run a single rms_norm_f32 test with the given dimensions.
+ * @brief Run a single rms_norm_f32 test with the given dimensions and epsilon.
  *
  * The test:
  *   1. Generates random input [ne1 x ne0] (float)
  *   2. Computes a CPU reference via rms_norm_f32_ref
- *   3. Calls htp_ops_rms_norm_f32 on the DSP
+ *   3. Calls htp_ops_rms_norm_f32 on the DSP (epsilon passed as int32 bits)
  *   4. Compares the DSP result against the CPU reference using MSE
  *
  * @param ne0  Number of elements per row (feature dimension)
  * @param ne1  Number of rows
+ * @param eps  Epsilon for numerical stability
  */
-static void run_rms_norm_f32_test(const int ne0, const int ne1) {
+static void run_rms_norm_f32_test(const int ne0, const int ne1,
+                                  const float eps) {
   auto &htp = htp::HtpInterface::instance();
 
   ASSERT_NE(htp.htp_ops_rms_norm_f32, nullptr)
@@ -746,7 +749,11 @@ static void run_rms_norm_f32_test(const int ne0, const int ne1) {
 
   // Compute CPU reference
   std::vector<float> ref_dst(ne0 * ne1);
-  rms_norm_f32_ref(ref_dst.data(), input.data(), ne0, ne1);
+  rms_norm_f32_ref(ref_dst.data(), input.data(), ne0, ne1, eps);
+
+  // Convert epsilon to int32 bit representation for RPC
+  int32_t eps_bits;
+  memcpy(&eps_bits, &eps, sizeof(float));
 
   // The kernel uses stride = ne0 (contiguous rows). The inner function
   // writes ceil(ne0/32) full vectors per row, so the last row may write
@@ -772,7 +779,8 @@ static void run_rms_norm_f32_test(const int ne0, const int ne1) {
   memcpy(src_ptr, input.data(), ne0 * ne1 * sizeof(float));
 
   // Run on DSP
-  err = htp.htp_ops_rms_norm_f32(handle, dst_fd, 0, src_fd, 0, ne0, ne1);
+  err = htp.htp_ops_rms_norm_f32(handle, dst_fd, 0, src_fd, 0, ne0, ne1,
+                                 eps_bits);
   ASSERT_EQ(err, 0) << "htp_ops_rms_norm_f32 failed";
 
   // Copy DSP result (only the ne0*ne1 logical elements)
@@ -780,7 +788,8 @@ static void run_rms_norm_f32_test(const int ne0, const int ne1) {
   memcpy(dsp_dst.data(), dst_ptr, ne0 * ne1 * sizeof(float));
 
   float mse_err = mse<float>(dsp_dst.data(), ref_dst.data(), ne0 * ne1);
-  std::cout << "RMS Norm F32: ne0=" << ne0 << ", ne1=" << ne1 << std::endl;
+  std::cout << "RMS Norm F32: ne0=" << ne0 << ", ne1=" << ne1
+            << ", eps=" << eps << std::endl;
   std::cout << " - MSE (vs CPU ref): " << mse_err << std::endl;
 
   EXPECT_IN_RANGE(mse_err, 0.0f, 1e-6f);
@@ -790,24 +799,30 @@ static void run_rms_norm_f32_test(const int ne0, const int ne1) {
   htp.free_shared_mem_buf(src_ptr, src_fd, buf_size);
 }
 
-#define DECLARE_rms_norm_f32_test(NE0, NE1)                                    \
-  TEST(nntrainer_htp_kernels, rms_norm_f32_##NE0##_##NE1) {                    \
-    run_rms_norm_f32_test(NE0, NE1);                                           \
+#define DECLARE_rms_norm_f32_test(NE0, NE1, EPS_TAG, EPS_VAL)                 \
+  TEST(nntrainer_htp_kernels, rms_norm_f32_##NE0##_##NE1##_##EPS_TAG) {       \
+    run_rms_norm_f32_test(NE0, NE1, EPS_VAL);                                 \
   }
 
-// Test with ne0 as multiples of 32 (no leftover elements)
-DECLARE_rms_norm_f32_test(32, 1);
-DECLARE_rms_norm_f32_test(128, 1);
-DECLARE_rms_norm_f32_test(4096, 1);
+// Test with eps=1e-5 (LLaMA default)
+// ne0 as multiples of 32 (no leftover elements)
+DECLARE_rms_norm_f32_test(32, 1, eps1e5, 1e-5f);
+DECLARE_rms_norm_f32_test(128, 1, eps1e5, 1e-5f);
+DECLARE_rms_norm_f32_test(4096, 1, eps1e5, 1e-5f);
 
-// Test with ne0 not a multiple of 32 (leftover handling)
-DECLARE_rms_norm_f32_test(100, 1);
-DECLARE_rms_norm_f32_test(4000, 1);
+// ne0 not a multiple of 32 (leftover handling)
+DECLARE_rms_norm_f32_test(100, 1, eps1e5, 1e-5f);
+DECLARE_rms_norm_f32_test(4000, 1, eps1e5, 1e-5f);
 
-// Test with multiple rows (ne1 > 1)
-DECLARE_rms_norm_f32_test(128, 8);
-DECLARE_rms_norm_f32_test(4096, 4);
-DECLARE_rms_norm_f32_test(4096, 16);
+// Multiple rows (ne1 > 1)
+DECLARE_rms_norm_f32_test(128, 8, eps1e5, 1e-5f);
+DECLARE_rms_norm_f32_test(4096, 4, eps1e5, 1e-5f);
+DECLARE_rms_norm_f32_test(4096, 16, eps1e5, 1e-5f);
+
+// Test with eps=1e-6 (Qwen3 default)
+DECLARE_rms_norm_f32_test(128, 1, eps1e6, 1e-6f);
+DECLARE_rms_norm_f32_test(4096, 1, eps1e6, 1e-6f);
+DECLARE_rms_norm_f32_test(4096, 4, eps1e6, 1e-6f);
 
 #else
 

--- a/test/unittest/unittest_htp_kernels.cpp
+++ b/test/unittest/unittest_htp_kernels.cpp
@@ -690,6 +690,125 @@ DECLARE_repack_q4_0x4_test(1, 512, 512);
 DECLARE_repack_q4_0x4_test(32, 1024, 256);
 DECLARE_repack_q4_0x4_test(128, 4096, 2048);
 
+/**
+ * @brief CPU reference implementation of RMS normalization (f32).
+ *
+ * For each row of ne0 elements:
+ *   scale = 1 / sqrt(mean(x^2) + eps)
+ *   y[i]  = x[i] * scale
+ *
+ * @param dst  Output buffer [ne1 x ne0]
+ * @param src  Input buffer  [ne1 x ne0]
+ * @param ne0  Number of elements per row (feature dimension)
+ * @param ne1  Number of rows
+ */
+static void rms_norm_f32_ref(float *dst, const float *src, int ne0, int ne1) {
+  const float eps = 1e-5f;
+  for (int j = 0; j < ne1; ++j) {
+    const float *x = src + j * ne0;
+    float       *y = dst + j * ne0;
+    float sum = 0.0f;
+    for (int i = 0; i < ne0; ++i) {
+      sum += x[i] * x[i];
+    }
+    float mean  = sum / ne0;
+    float scale = 1.0f / std::sqrt(mean + eps);
+    for (int i = 0; i < ne0; ++i) {
+      y[i] = x[i] * scale;
+    }
+  }
+}
+
+/**
+ * @brief Run a single rms_norm_f32 test with the given dimensions.
+ *
+ * The test:
+ *   1. Generates random input [ne1 x ne0] (float)
+ *   2. Computes a CPU reference via rms_norm_f32_ref
+ *   3. Calls htp_ops_rms_norm_f32 on the DSP
+ *   4. Compares the DSP result against the CPU reference using MSE
+ *
+ * @param ne0  Number of elements per row (feature dimension)
+ * @param ne1  Number of rows
+ */
+static void run_rms_norm_f32_test(const int ne0, const int ne1) {
+  auto &htp = htp::HtpInterface::instance();
+
+  ASSERT_NE(htp.htp_ops_rms_norm_f32, nullptr)
+    << "HTP library not loaded (htp_ops_rms_norm_f32 missing)";
+
+  auto handle = htp.get_global_handle();
+  ASSERT_NE(handle, (uint64_t)0) << "DSP session not opened (handle == 0)";
+
+  // Generate random input data
+  std::vector<float> input =
+    generate_random_vector<float, false>(ne0 * ne1, -1.0f, 1.0f);
+
+  // Compute CPU reference
+  std::vector<float> ref_dst(ne0 * ne1);
+  rms_norm_f32_ref(ref_dst.data(), input.data(), ne0, ne1);
+
+  // The kernel uses stride = ne0 (contiguous rows). The inner function
+  // writes ceil(ne0/32) full vectors per row, so the last row may write
+  // past ne0*ne1 floats. Allocate enough to cover that overflow.
+  int ne0_padded = ((ne0 + 31) / 32) * 32;
+  size_t buf_size =
+    (size_t)((ne1 > 0 ? (ne1 - 1) * ne0 : 0) + ne0_padded) * sizeof(float);
+
+  // Allocate shared memory for DSP
+  float *src_ptr = nullptr;
+  float *dst_ptr = nullptr;
+  int src_fd, dst_fd;
+
+  int err = htp.alloc_shared_mem_buf((void **)&dst_ptr, &dst_fd, buf_size);
+  ASSERT_EQ(err, 0) << "Failed to allocate output buffer";
+
+  err = htp.alloc_shared_mem_buf((void **)&src_ptr, &src_fd, buf_size);
+  ASSERT_EQ(err, 0) << "Failed to allocate input buffer";
+
+  // Copy input data contiguously (kernel uses stride = ne0).
+  // Zero-fill first to clear any padding beyond ne0*ne1.
+  memset(src_ptr, 0, buf_size);
+  memcpy(src_ptr, input.data(), ne0 * ne1 * sizeof(float));
+
+  // Run on DSP
+  err = htp.htp_ops_rms_norm_f32(handle, dst_fd, 0, src_fd, 0, ne0, ne1);
+  ASSERT_EQ(err, 0) << "htp_ops_rms_norm_f32 failed";
+
+  // Copy DSP result (only the ne0*ne1 logical elements)
+  std::vector<float> dsp_dst(ne0 * ne1);
+  memcpy(dsp_dst.data(), dst_ptr, ne0 * ne1 * sizeof(float));
+
+  float mse_err = mse<float>(dsp_dst.data(), ref_dst.data(), ne0 * ne1);
+  std::cout << "RMS Norm F32: ne0=" << ne0 << ", ne1=" << ne1 << std::endl;
+  std::cout << " - MSE (vs CPU ref): " << mse_err << std::endl;
+
+  EXPECT_IN_RANGE(mse_err, 0.0f, 1e-6f);
+
+  // Cleanup
+  htp.free_shared_mem_buf(dst_ptr, dst_fd, buf_size);
+  htp.free_shared_mem_buf(src_ptr, src_fd, buf_size);
+}
+
+#define DECLARE_rms_norm_f32_test(NE0, NE1)                                    \
+  TEST(nntrainer_htp_kernels, rms_norm_f32_##NE0##_##NE1) {                    \
+    run_rms_norm_f32_test(NE0, NE1);                                           \
+  }
+
+// Test with ne0 as multiples of 32 (no leftover elements)
+DECLARE_rms_norm_f32_test(32, 1);
+DECLARE_rms_norm_f32_test(128, 1);
+DECLARE_rms_norm_f32_test(4096, 1);
+
+// Test with ne0 not a multiple of 32 (leftover handling)
+DECLARE_rms_norm_f32_test(100, 1);
+DECLARE_rms_norm_f32_test(4000, 1);
+
+// Test with multiple rows (ne1 > 1)
+DECLARE_rms_norm_f32_test(128, 8);
+DECLARE_rms_norm_f32_test(4096, 4);
+DECLARE_rms_norm_f32_test(4096, 16);
+
 #else
 
 TEST(nntrainer_htp_kernels, htp_not_enabled) {


### PR DESCRIPTION
## Summary

- Wire Qwen3's RMSNorm path to the HVX `hvx_rms_norm_f32` kernel by adding HTP dispatch to `RMSNormLayer` (attention/ffn/output norm) and `ReshapedRMSNormLayer` (q/k norm), with CPU fallback preserved under `ENABLE_HTP` guards.
- Parameterize epsilon through the full HVX kernel / FastRPC chain (previously hard-coded), and extend the HTP kernel unit test to cover eps=1e-5 / 1e-6.
- Fix Android NDK build by adding `nntrainer/tensor/htp_backend` to `causallm_core`'s include path when `ENABLE_HTP=1`, so `htp_interface.h` resolves for the layer sources.

## Commits included
- `b9615e3` add htp_backend include to causallm_core Android target
- `c3c0248` dispatch rms_norm to HTP kernel in CausalLM layers
- `e1f9803` parameterize epsilon in HVX rms_norm kernel and update full RPC chain
- `682d209` add subprojects/.wraplock to .gitignore
- `6133502` add rms_norm_f32 unit test for HTP kernel verification

## Test plan
- [ ] Linux host build with HTP OFF — CPU fallback regression (Tensor-op path unchanged)
- [ ] Android cross build with `-Denable-htp=true` / `ENABLE_HTP=1` via `build_android.sh`
- [ ] `unittest_htp_kernels` rms_norm cases (eps=1e-5, 1e-6)
- [ ] Qwen3-0.6B end-to-end inference on device: HTP ON vs HTP OFF output comparison (greedy decoding identity; logit MSE within tolerance)
- [ ] Verify all `attention_norm` / `ffn_norm` / `output_norm` / `q_norm` / `k_norm` call sites take the HTP path

https://claude.ai/code/session_0111J2dauDChZPAoYPeCsCqY